### PR TITLE
fix: GitHub Actions artifact v4로 업데이트

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -99,7 +99,7 @@ jobs:
 
     steps:
       - name: Download backend JAR artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: backend-jar
           path: ./backend-jar


### PR DESCRIPTION
GitHub Actions에서 `actions/download-artifact` v3를 더 이상 지원하지 않아
배포 단계에서 오류가 발생함.

artifact 관련 액션을 v4로 수정(업데이트)하여
배포 단계 오류 해결

- v3 → v4