### PR TITLE
fix: 빌드된 JAR 파일 EC2 경로에 맞게 복사 경로 수정

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -111,12 +111,12 @@ jobs:
 
       # 빌드된 JAR를 EC2로 복사
       - name: Copy backend JAR to EC2
-        run: scp -o StrictHostKeyChecking=no ./backend-jar/*.jar ec2-user@${{ secrets.EC2_HOST }}:/home/ec2-user/snwa/app.jar
+        run: scp -o StrictHostKeyChecking=no ./backend-jar/*.jar ec2-user@${{ secrets.EC2_HOST }}:/home/ec2-user/final-project-snwa/snwa-backend/app.jar
 
       - name: Deploy to EC2 (Blue-Green)
         run: |
           ssh -o StrictHostKeyChecking=no ec2-user@${{ secrets.EC2_HOST }} << 'EOF'
-            cd /home/ec2-user/snwa
+            cd /home/ec2-user/final-project-snwa
 
             # git 소스 업데이트는 필요하면 유지하거나 주석처리 가능
             # git fetch origin develop
@@ -136,8 +136,8 @@ jobs:
             echo "NEW=$NEW (Port:$NEW_PORT), OLD=$OLD"
             
             # 1. 빌드된 JAR를 백엔드 도커 빌드 경로로 이동
-            mv /home/ec2-user/snwa/app.jar /home/ec2-user/snwa/snwa-backend/app.jar
-            
+            mv /home/ec2-user/final-project-snwa/snwa-backend/app.jar /home/ec2-user/final-project-snwa/snwa-backend/app.jar
+      
             # 2. 새 컨테이너 빌드 및 실행
             docker-compose build snwa-backend-$NEW
             docker-compose up -d snwa-backend-$NEW
@@ -146,7 +146,7 @@ jobs:
             sleep 20
             
             # 4. [핵심] Nginx가 바라보는 변수 파일 수정
-            echo "set \$service_url http://snwa-backend-$NEW:$NEW_PORT;" | sudo tee /home/ec2-user/snwa/nginx/service-url.inc
+            echo "set \$service_url http://snwa-backend-$NEW:$NEW_PORT;" | sudo tee /home/ec2-user/final-project-snwa/nginx/service-url.inc
             
             # 5. Nginx 설정 재로드
             docker exec snwa-nginx nginx -s reload

--- a/Docker-compose.yml
+++ b/Docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   mysql:
     image: mysql:8.0
+    container_name: snwa-mysql
     expose:
       - 3306
     environment:
@@ -19,6 +20,7 @@ services:
   snwa-backend-blue:
     build: ./snwa-backend
     image: snwa-backend-server:blue
+    container_name: snwa-backend-server-blue
     expose:
       - 8080
     depends_on:
@@ -48,6 +50,7 @@ services:
   snwa-backend-green:
     build: ./snwa-backend
     image: snwa-backend-server:green
+    container_name: snwa-backend-server-green
     expose:
       - 8081
     depends_on:
@@ -77,6 +80,7 @@ services:
   snwa-frontend:
     build: ./snwa-frontend
     image: snwa-frontend-server:v1
+    container_name: snwa-frontend-server
     networks:
       - frontend-net
 


### PR DESCRIPTION
1. 이전 경로가 잘못되어 배포 시 파일을 찾지 못하는 문제
- 빌드된 JAR 파일 복사 경로를 EC2 실제 경로에 맞게 정정

2. Docker-compose 수정
- 컨테이너 이름 지정 (Ex: container_name: snwa-backend-server-green)