### PR TITLE
fix: cd 환경에서 docker - 제거

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -124,33 +124,30 @@ jobs:
             # git reset --hard origin/develop
 
             if docker ps --format '{{.Names}}' | grep -q snwa-backend-blue; then
-            NEW=green
-            OLD=blue
-            NEW_PORT=8081
+              NEW=green
+              OLD=blue
+              NEW_PORT=8081
             else
-            NEW=blue
-            OLD=green
-            NEW_PORT=8080
+              NEW=blue
+              OLD=green
+              NEW_PORT=8080
             fi
             
             echo "NEW=$NEW (Port:$NEW_PORT), OLD=$OLD"
+                  
+            # 1. 새 컨테이너 빌드 및 실행
+            docker compose build snwa-backend-$NEW
+            docker compose up -d snwa-backend-$NEW
             
-            # 1. 빌드된 JAR를 백엔드 도커 빌드 경로로 이동
-            mv /home/ec2-user/final-project-snwa/snwa-backend/app.jar /home/ec2-user/final-project-snwa/snwa-backend/app.jar
-      
-            # 2. 새 컨테이너 빌드 및 실행
-            docker-compose build snwa-backend-$NEW
-            docker-compose up -d snwa-backend-$NEW
-            
-            # 3. 신규 컨테이너가 뜰 때까지 잠시 대기 (Health Check 대용)
+            # 2. 신규 컨테이너가 뜰 때까지 잠시 대기 (Health Check 대용)
             sleep 20
             
-            # 4. [핵심] Nginx가 바라보는 변수 파일 수정
+            # 3. [핵심] Nginx가 바라보는 변수 파일 수정
             echo "set \$service_url http://snwa-backend-$NEW:$NEW_PORT;" | sudo tee /home/ec2-user/final-project-snwa/nginx/service-url.inc
             
-            # 5. Nginx 설정 재로드
+            # 4. Nginx 설정 재로드
             docker exec snwa-nginx nginx -s reload
             
-            # 6. 이전 컨테이너 종료
-            docker-compose stop snwa-backend-$OLD  
+            # 5. 이전 컨테이너 종료
+            docker compose stop snwa-backend-$OLD || true
           EOF


### PR DESCRIPTION
1. Amazon Linux 환경에 맞춰 코드 수정
- docker -  시 하이폰을 안 쓴다.
- docker-compose 명령어를 docker compose로 교체

2. CD 환경에서 이전 컨테이너 종료시 예외 처리 코드 추가
- 기존 컨테이너 중지 시 대상이 없는 경우를 대비해 예외 처리(|| true) 추가