### PR TITLE
배포 시 Ec2 소스코드 자동 동기화 로직 추가

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -118,10 +118,10 @@ jobs:
           ssh -o StrictHostKeyChecking=no ec2-user@${{ secrets.EC2_HOST }} << 'EOF'
             cd /home/ec2-user/final-project-snwa
 
-            # git 소스 업데이트는 필요하면 유지하거나 주석처리 가능
-            # git fetch origin develop
-            # git checkout develop
-            # git reset --hard origin/develop
+            # EC2 서버의 소스코드를 GitHub 최신 상태와 동기화
+            git fetch origin develop  # 원격의 최신 정보를 가져옴
+            git checkout develop
+            git reset --hard origin/develop   # GitHub의 develop 상태와 서버를 동기화
 
             if docker ps --format '{{.Names}}' | grep -q snwa-backend-blue; then
               NEW=green


### PR DESCRIPTION
1. EC2 서버의 소스코드를 GitHub 최신 상태와 동기화 로직 추가
- develop 브랜치 머지 후 CI 통과 시 EC2 서버에서 수동 git pull 없이 소스 코드가 자동으로 동기화되도록 구성