### PR TITLE
feat: 기사 목록 페이징, 종목/퍼블리셔 별 태그 조회 추가

### DIFF
--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/article/controller/ArticleController.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/article/controller/ArticleController.java
@@ -2,18 +2,18 @@ package com.team.snwa.snwabackend.domain.article.controller;
 
 import com.team.snwa.snwabackend.domain.article.dto.ArticleDetailResponseDto;
 import com.team.snwa.snwabackend.domain.article.dto.ArticleListResponseDto;
+import com.team.snwa.snwabackend.domain.article.entity.Category;
 import com.team.snwa.snwabackend.domain.article.dto.request.ArticleCreateRequestDto;
 import com.team.snwa.snwabackend.domain.article.service.ArticleService;
 import com.team.snwa.snwabackend.domain.user.entity.User;
 import com.team.snwa.snwabackend.domain.user.repository.UserRepository;
-import com.team.snwa.snwabackend.global.exception.CustomException;
-import com.team.snwa.snwabackend.global.exception.ErrorCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
@@ -27,33 +27,23 @@ public class ArticleController {
     private final ArticleService articleService;
     private final UserRepository userRepository;
 
-    /** Principal(이메일)이 있으면 User 조회, 없으면 null */
+    /** Principal(이메일)이 있으면 User 조회, 없으면 null — 카테고리별 클릭(ClickLog)용 */
     private User resolveUser(Principal principal) {
         if (principal == null || principal.getName() == null) return null;
         return userRepository.findByEmail(principal.getName()).orElse(null);
     }
 
-    /** Principal에서 User 조회 (필수 인증, 없으면 예외) */
-    private User getRequiredUser(Principal principal) {
-        if (principal == null || principal.getName() == null) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
-        return userRepository.findByEmail(principal.getName())
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-    }
-
     /**
      * 기사 생성
      * @param request 생성 요청 (categoryId, title, content 필수)
-     * @param principal 인증된 사용자 (이메일)
+     * @param user 인증된 사용자 (글 작성자)
      * @return 생성된 기사 상세 정보
      */
     @PostMapping
     public ResponseEntity<ArticleDetailResponseDto> createArticle(
             @Valid @RequestBody ArticleCreateRequestDto request,
-            Principal principal
+            @AuthenticationPrincipal User user
     ) {
-        User user = getRequiredUser(principal);
         ArticleDetailResponseDto created = articleService.createArticle(user, request);
         return ResponseEntity.status(org.springframework.http.HttpStatus.CREATED).body(created);
     }
@@ -61,19 +51,35 @@ public class ArticleController {
     /**
      * 기사 목록 조회
      * @param categoryId 카테고리 ID (선택적)
+     * @param publisherName 출판사명 (선택적)
      * @param pageable 페이지 정보 (기본값: size=10, sort=createdDate,desc)
-     * @param principal 인증된 사용자 (이메일, 없으면 null)
      * @return 기사 목록
      */
     @GetMapping
     public ResponseEntity<Page<ArticleListResponseDto>> getArticleList(
             @RequestParam(required = false) Long categoryId,
+            @RequestParam(required = false) String publisherName,
             @PageableDefault(size = 10, sort = "createdDate", direction = org.springframework.data.domain.Sort.Direction.DESC) Pageable pageable,
-            Principal principal
+            @AuthenticationPrincipal User user
     ) {
-        User user = resolveUser(principal);
-        Page<ArticleListResponseDto> articles = articleService.getArticleList(categoryId, pageable, user);
+        Page<ArticleListResponseDto> articles = articleService.getArticleList(categoryId, publisherName, pageable, user);
         return ResponseEntity.ok(articles);
+    }
+
+    /**
+     * 카테고리(종목) 목록 조회
+     */
+    @GetMapping("/categories")
+    public ResponseEntity<List<Category>> getCategories() {
+        return ResponseEntity.ok(articleService.getCategories());
+    }
+
+    /**
+     * 출판사 목록 조회 (기사에 등장하는 출판사명)
+     */
+    @GetMapping("/publishers")
+    public ResponseEntity<List<String>> getPublishers() {
+        return ResponseEntity.ok(articleService.getPublisherNames());
     }
 
     /**
@@ -95,15 +101,13 @@ public class ArticleController {
     /**
      * 관련 기사 조회 (같은 카테고리의 최신 기사 3개, 현재 기사 제외)
      * @param id 현재 기사 ID
-     * @param principal 인증된 사용자 (이메일, 없으면 null)
      * @return 관련 기사 목록 (최대 3개)
      */
     @GetMapping("/{id}/related")
     public ResponseEntity<List<ArticleListResponseDto>> getRelatedArticles(
             @PathVariable Long id,
-            Principal principal
+            @AuthenticationPrincipal User user
     ) {
-        User user = resolveUser(principal);
         List<ArticleListResponseDto> relatedArticles = articleService.getRelatedArticles(id, user);
         return ResponseEntity.ok(relatedArticles);
     }
@@ -112,16 +116,14 @@ public class ArticleController {
      * 기사 검색 (제목 + 내용)
      * @param keyword 검색어
      * @param pageable 페이지 정보 (기본값: size=10, sort=createdDate,desc)
-     * @param principal 인증된 사용자 (이메일, 없으면 null)
      * @return 검색된 기사 목록
      */
     @GetMapping("/search")
     public ResponseEntity<Page<ArticleListResponseDto>> searchArticles(
             @RequestParam String keyword,
             @PageableDefault(size = 10, sort = "createdDate", direction = org.springframework.data.domain.Sort.Direction.DESC) Pageable pageable,
-            Principal principal
+            @AuthenticationPrincipal User user
     ) {
-        User user = resolveUser(principal);
         Page<ArticleListResponseDto> articles = articleService.searchArticles(keyword, pageable, user);
         return ResponseEntity.ok(articles);
     }
@@ -130,16 +132,14 @@ public class ArticleController {
      * 제목만 검색
      * @param keyword 검색어
      * @param pageable 페이지 정보 (기본값: size=10, sort=createdDate,desc)
-     * @param principal 인증된 사용자 (이메일, 없으면 null)
      * @return 검색된 기사 목록
      */
     @GetMapping("/search/title")
     public ResponseEntity<Page<ArticleListResponseDto>> searchByTitle(
             @RequestParam String keyword,
             @PageableDefault(size = 10, sort = "createdDate", direction = org.springframework.data.domain.Sort.Direction.DESC) Pageable pageable,
-            Principal principal
+            @AuthenticationPrincipal User user
     ) {
-        User user = resolveUser(principal);
         Page<ArticleListResponseDto> articles = articleService.searchByTitle(keyword, pageable, user);
         return ResponseEntity.ok(articles);
     }
@@ -148,16 +148,14 @@ public class ArticleController {
      * 내용만 검색
      * @param keyword 검색어
      * @param pageable 페이지 정보 (기본값: size=10, sort=createdDate,desc)
-     * @param principal 인증된 사용자 (이메일, 없으면 null)
      * @return 검색된 기사 목록
      */
     @GetMapping("/search/content")
     public ResponseEntity<Page<ArticleListResponseDto>> searchByContent(
             @RequestParam String keyword,
             @PageableDefault(size = 10, sort = "createdDate", direction = org.springframework.data.domain.Sort.Direction.DESC) Pageable pageable,
-            Principal principal
+            @AuthenticationPrincipal User user
     ) {
-        User user = resolveUser(principal);
         Page<ArticleListResponseDto> articles = articleService.searchByContent(keyword, pageable, user);
         return ResponseEntity.ok(articles);
     }

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/article/controller/BookmarkController.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/article/controller/BookmarkController.java
@@ -3,17 +3,14 @@ package com.team.snwa.snwabackend.domain.article.controller;
 import com.team.snwa.snwabackend.domain.article.dto.ArticleListResponseDto;
 import com.team.snwa.snwabackend.domain.article.service.BookmarkService;
 import com.team.snwa.snwabackend.domain.user.entity.User;
-import com.team.snwa.snwabackend.domain.user.repository.UserRepository;
-import com.team.snwa.snwabackend.global.exception.CustomException;
-import com.team.snwa.snwabackend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.security.Principal;
 import java.util.Map;
 
 @RestController
@@ -22,25 +19,18 @@ import java.util.Map;
 public class BookmarkController {
 
     private final BookmarkService bookmarkService;
-    private final UserRepository userRepository;
-
-    private User getCurrentUser(Principal principal) {
-        return userRepository.findByEmail(principal.getName())
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-    }
 
     /**
      * 즐겨찾기 추가
      * @param articleId 기사 ID
-     * @param principal 인증된 사용자 (이메일)
+     * @param user 인증된 사용자
      * @return 성공 응답
      */
     @PostMapping("/{articleId}")
     public ResponseEntity<Map<String, String>> addBookmark(
             @PathVariable Long articleId,
-            Principal principal
+            @AuthenticationPrincipal User user
     ) {
-        User user = getCurrentUser(principal);
         bookmarkService.addBookmark(user, articleId);
         return ResponseEntity.ok(Map.of("message", "즐겨찾기가 추가되었습니다."));
     }
@@ -48,31 +38,29 @@ public class BookmarkController {
     /**
      * 즐겨찾기 삭제
      * @param articleId 기사 ID
-     * @param principal 인증된 사용자 (이메일)
+     * @param user 인증된 사용자
      * @return 성공 응답
      */
     @DeleteMapping("/{articleId}")
     public ResponseEntity<Map<String, String>> removeBookmark(
             @PathVariable Long articleId,
-            Principal principal
+            @AuthenticationPrincipal User user
     ) {
-        User user = getCurrentUser(principal);
         bookmarkService.removeBookmark(user, articleId);
         return ResponseEntity.ok(Map.of("message", "즐겨찾기가 삭제되었습니다."));
     }
 
     /**
      * 내 즐겨찾기 목록 조회
-     * @param principal 인증된 사용자 (이메일)
+     * @param user 인증된 사용자
      * @param pageable 페이지 정보 (기본값: size=10, sort=createdDate,desc)
      * @return 즐겨찾기한 기사 목록
      */
     @GetMapping("/me")
     public ResponseEntity<Page<ArticleListResponseDto>> getMyBookmarks(
-            Principal principal,
+            @AuthenticationPrincipal User user,
             @PageableDefault(size = 10, sort = "createdDate", direction = org.springframework.data.domain.Sort.Direction.DESC) Pageable pageable
     ) {
-        User user = getCurrentUser(principal);
         Page<ArticleListResponseDto> bookmarks = bookmarkService.getBookmarks(user, pageable);
         return ResponseEntity.ok(bookmarks);
     }
@@ -80,29 +68,27 @@ public class BookmarkController {
     /**
      * 특정 기사의 즐겨찾기 여부 확인
      * @param articleId 기사 ID
-     * @param principal 인증된 사용자 (이메일)
+     * @param user 인증된 사용자
      * @return 즐겨찾기 여부
      */
     @GetMapping("/{articleId}/check")
     public ResponseEntity<Map<String, Boolean>> checkBookmark(
             @PathVariable Long articleId,
-            Principal principal
+            @AuthenticationPrincipal User user
     ) {
-        User user = getCurrentUser(principal);
         boolean isBookmarked = bookmarkService.isBookmarked(user, articleId);
         return ResponseEntity.ok(Map.of("isBookmarked", isBookmarked));
     }
 
     /**
      * 내 즐겨찾기 개수 조회
-     * @param principal 인증된 사용자 (이메일)
+     * @param user 인증된 사용자
      * @return 즐겨찾기 개수
      */
     @GetMapping("/me/count")
     public ResponseEntity<Map<String, Long>> getMyBookmarkCount(
-            Principal principal
+            @AuthenticationPrincipal User user
     ) {
-        User user = getCurrentUser(principal);
         long count = bookmarkService.getBookmarkCount(user);
         return ResponseEntity.ok(Map.of("count", count));
     }

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/article/repository/ArticleRepository.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/article/repository/ArticleRepository.java
@@ -19,9 +19,11 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
             "LEFT JOIN FETCH a.category " +
             "WHERE a.deletedAt IS NULL " +
             "AND (:categoryId IS NULL OR a.category.id = :categoryId) " +
+            "AND (:publisherName IS NULL OR :publisherName = '' OR a.publisherName = :publisherName) " +
             "ORDER BY a.createdDate DESC")
     Page<Article> findAllWithCategory(
             @Param("categoryId") Long categoryId,
+            @Param("publisherName") String publisherName,
             Pageable pageable
     );
 
@@ -117,6 +119,12 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     boolean existsByOriginalUrl(String originalUrl);
 
     Optional<Article> findByOriginalUrl(String originalUrl);
+
+    /**
+     * 삭제되지 않은 기사에서 출판사명 목록 (중복 제거, null/빈 문자열 제외)
+     */
+    @Query("SELECT DISTINCT a.publisherName FROM Article a WHERE a.deletedAt IS NULL AND a.publisherName IS NOT NULL AND a.publisherName != '' ORDER BY a.publisherName")
+    List<String> findDistinctPublisherNames();
 
     /**
      * 번역이 안된 기사 조회 (translatedTitle 또는 translatedContent가 null인 기사)

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/article/service/ArticleService.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/article/service/ArticleService.java
@@ -77,15 +77,30 @@ public class ArticleService {
     /**
      * 기사 목록 조회
      * @param categoryId 카테고리 ID (선택적, null이면 전체 조회)
+     * @param publisherName 출판사명 (선택적, null/빈 문자열이면 전체)
      * @param pageable 페이지 정보
      * @param user 인증된 사용자 (null이면 비로그인, isBookmarked는 false)
      * @return 기사 목록
      */
-    public Page<ArticleListResponseDto> getArticleList(Long categoryId, Pageable pageable, User user) {
-        Page<Article> articles = articleRepository.findAllWithCategory(categoryId, pageable);
+    public Page<ArticleListResponseDto> getArticleList(Long categoryId, String publisherName, Pageable pageable, User user) {
+        Page<Article> articles = articleRepository.findAllWithCategory(categoryId, publisherName, pageable);
         Set<Long> bookmarkedIds = bookmarkService.getBookmarkedArticleIds(user,
                 articles.getContent().stream().map(Article::getId).toList());
         return articles.map(a -> ArticleListResponseDto.from(a, bookmarkedIds.contains(a.getId())));
+    }
+
+    /**
+     * 카테고리(종목) 목록 조회
+     */
+    public List<Category> getCategories() {
+        return categoryRepository.findAll();
+    }
+
+    /**
+     * 기사에 등장하는 출판사명 목록 (중복 제거)
+     */
+    public List<String> getPublisherNames() {
+        return articleRepository.findDistinctPublisherNames();
     }
 
     /**

--- a/snwa-frontend/src/pages/MainPage.tsx
+++ b/snwa-frontend/src/pages/MainPage.tsx
@@ -33,6 +33,8 @@ const API_CATEGORY_TO_DISPLAY: Record<string, 'Football' | 'Soccer' | 'Basketbal
     FOOTBALL: 'Football',
 };
 
+type ApiCategory = { id: number; categoryName: string };
+
 function getAuthHeader(): Record<string, string> | null {
     const token = sessionStorage.getItem('snwa_token');
     if (!token) return null;
@@ -56,6 +58,8 @@ function mapListItemToArticle(item: ApiArticleListItem): Article {
 }
 
 export default function MainPage() {
+    const PAGE_SIZE = 12;
+
     const [articles, setArticles] = useState<Article[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -64,20 +68,40 @@ export default function MainPage() {
     const [searchKeyword, setSearchKeyword] = useState('');
     /** 검색 범위: 전체(제목+내용), 제목, 내용 */
     const [searchScope, setSearchScope] = useState<'all' | 'title' | 'content'>('all');
+    /** 현재 페이지 (0-based, API와 동일) */
+    const [currentPage, setCurrentPage] = useState(0);
+    /** 전체 페이지 수 (API 응답 기준) */
+    const [totalPages, setTotalPages] = useState(0);
+    /** 전체 기사 수 */
+    const [totalElements, setTotalElements] = useState(0);
+    /** 스포츠 종목 태그 선택 (카테고리 ID, null이면 전체) */
+    const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
+    /** 퍼블리셔 태그 선택 (null이면 전체) */
+    const [selectedPublisher, setSelectedPublisher] = useState<string | null>(null);
+    /** 카테고리 목록 (태그용) */
+    const [categories, setCategories] = useState<ApiCategory[]>([]);
+    /** 퍼블리셔 목록 (태그용) */
+    const [publishers, setPublishers] = useState<string[]>([]);
 
     const fetchArticles = useCallback(() => {
         const headers: Record<string, string> = {};
         const auth = getAuthHeader();
         if (auth) Object.assign(headers, auth);
 
+        const pageParam = `page=${currentPage}&size=${PAGE_SIZE}`;
         let url: string;
         if (!searchKeyword) {
-            url = '/api/articles';
+            const params = new URLSearchParams();
+            params.set('page', String(currentPage));
+            params.set('size', String(PAGE_SIZE));
+            if (selectedCategoryId != null) params.set('categoryId', String(selectedCategoryId));
+            if (selectedPublisher != null && selectedPublisher !== '') params.set('publisherName', selectedPublisher);
+            url = `/api/articles?${params.toString()}`;
         } else {
             const encoded = encodeURIComponent(searchKeyword);
-            if (searchScope === 'title') url = `/api/articles/search/title?keyword=${encoded}`;
-            else if (searchScope === 'content') url = `/api/articles/search/content?keyword=${encoded}`;
-            else url = `/api/articles/search?keyword=${encoded}`;
+            if (searchScope === 'title') url = `/api/articles/search/title?keyword=${encoded}&${pageParam}`;
+            else if (searchScope === 'content') url = `/api/articles/search/content?keyword=${encoded}&${pageParam}`;
+            else url = `/api/articles/search?keyword=${encoded}&${pageParam}`;
         }
 
         setLoading(true);
@@ -90,26 +114,117 @@ export default function MainPage() {
             .then((data: ApiArticleListResponse) => {
                 const list = data.content ?? [];
                 setArticles(list.map(mapListItemToArticle));
+                setTotalPages(data.totalPages ?? 0);
+                setTotalElements(data.totalElements ?? 0);
             })
             .catch((e) => {
                 setError(e instanceof Error ? e.message : '기사를 불러오지 못했습니다.');
                 setArticles([]);
+                setTotalPages(0);
+                setTotalElements(0);
             })
             .finally(() => setLoading(false));
-    }, [searchKeyword, searchScope]);
+    }, [searchKeyword, searchScope, currentPage, selectedCategoryId, selectedPublisher]);
 
     useEffect(() => {
         fetchArticles();
     }, [fetchArticles]);
 
+    /** 카테고리·퍼블리셔 목록 로드 */
+    useEffect(() => {
+        const headers: Record<string, string> = {};
+        const auth = getAuthHeader();
+        if (auth) Object.assign(headers, auth);
+        Promise.all([
+            fetch('/api/articles/categories', { headers }).then((r) => (r.ok ? r.json() : [])),
+            fetch('/api/articles/publishers', { headers }).then((r) => (r.ok ? r.json() : [])),
+        ])
+            .then(([catList, pubList]) => {
+                setCategories(Array.isArray(catList) ? catList : []);
+                setPublishers(Array.isArray(pubList) ? pubList : []);
+            })
+            .catch(() => {});
+    }, []);
+
+    /** 검색 범위 / 태그 변경 시 첫 페이지로 */
+    useEffect(() => {
+        setCurrentPage(0);
+    }, [searchScope, selectedCategoryId, selectedPublisher]);
+
     const handleSearch = () => {
         setSearchKeyword(searchInput.trim());
+        setCurrentPage(0);
     };
 
     const handleClearSearch = () => {
         setSearchInput('');
         setSearchKeyword('');
     };
+
+    const categoryLabel = (name: string) => API_CATEGORY_TO_DISPLAY[name] ?? name;
+
+    const filterTags = (
+        <div className="mb-6 flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+                <span className="text-sm font-medium text-gray-700">스포츠 종목</span>
+                <div className="flex flex-wrap gap-2">
+                    <button
+                        type="button"
+                        onClick={() => setSelectedCategoryId(null)}
+                        className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
+                            selectedCategoryId === null
+                                ? 'bg-gray-900 text-white'
+                                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                        }`}
+                    >
+                        전체
+                    </button>
+                    {categories.map((c) => (
+                        <button
+                            key={c.id}
+                            type="button"
+                            onClick={() => setSelectedCategoryId(selectedCategoryId === c.id ? null : c.id)}
+                            className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
+                                selectedCategoryId === c.id
+                                    ? 'bg-gray-900 text-white'
+                                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                            }`}
+                        >
+                            {categoryLabel(c.categoryName)}
+                        </button>
+                    ))}
+                </div>
+            </div>
+            <div className="flex flex-col gap-2">
+                <span className="text-sm font-medium text-gray-700">퍼블리셔</span>
+                <div className="flex flex-wrap gap-2">
+                    <button
+                        type="button"
+                        onClick={() => setSelectedPublisher(null)}
+                        className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
+                            selectedPublisher === null
+                                ? 'bg-gray-900 text-white'
+                                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                        }`}
+                    >
+                        전체
+                    </button>
+                    {publishers.map((p) => (
+                        <button
+                            key={p}
+                            type="button"
+                            onClick={() => setSelectedPublisher(selectedPublisher === p ? null : p)}
+                            className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
+                                selectedPublisher === p ? 'bg-gray-900 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                            }`}
+                        >
+                            {p}
+                        </button>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
 
     const searchBar = (
         <div className="mb-6 flex flex-col gap-3">
@@ -154,6 +269,7 @@ export default function MainPage() {
                 <Header />
                 <main className="max-w-4xl mx-auto px-4 py-8">
                     {searchBar}
+                    {!searchKeyword && filterTags}
                     <div className="py-16 text-center">
                         <p className="text-gray-500">기사를 불러오는 중...</p>
                     </div>
@@ -168,6 +284,7 @@ export default function MainPage() {
                 <Header />
                 <main className="max-w-4xl mx-auto px-4 py-8">
                     {searchBar}
+                    {!searchKeyword && filterTags}
                     <div className="py-16 text-center">
                         <p className="text-gray-500">{error}</p>
                         <Link to="/" className="text-gray-900 font-medium hover:underline mt-4 inline-block">
@@ -187,6 +304,7 @@ export default function MainPage() {
                 <Header />
                 <main className="max-w-4xl mx-auto px-4 py-8">
                     {searchBar}
+                    {!searchKeyword && filterTags}
                     <div className="py-16 text-center">
                         <p className="text-gray-500">{emptyMessage}</p>
                         {searchKeyword && (
@@ -214,6 +332,7 @@ export default function MainPage() {
             <Header />
             <main className="max-w-4xl mx-auto px-4 py-8">
                 {searchBar}
+                {!searchKeyword && filterTags}
                 {searchKeyword && (
                     <div className="mb-4 flex items-center gap-2 text-sm text-gray-500">
                         <span>검색어: &quot;{searchKeyword}&quot;</span>
@@ -232,6 +351,46 @@ export default function MainPage() {
                         <ArticleCard key={article.id} article={article} />
                     ))}
                 </div>
+
+                {totalPages > 0 && (
+                    <nav className="mt-10 flex flex-col items-center gap-2" aria-label="페이지 네비게이션">
+                        <p className="text-sm text-gray-500">
+                            전체 {totalElements}건 · {currentPage + 1} / {totalPages} 페이지
+                        </p>
+                        <div className="flex flex-wrap items-center justify-center gap-1">
+                            <button
+                                type="button"
+                                onClick={() => setCurrentPage((p) => Math.max(0, p - 1))}
+                                disabled={currentPage === 0}
+                                className="min-w-[2.25rem] h-9 px-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:pointer-events-none"
+                            >
+                                이전
+                            </button>
+                            {Array.from({ length: totalPages }, (_, i) => i).map((page) => (
+                                <button
+                                    key={page}
+                                    type="button"
+                                    onClick={() => setCurrentPage(page)}
+                                    className={`min-w-[2.25rem] h-9 px-2 text-sm font-medium rounded-md transition-colors ${
+                                        page === currentPage
+                                            ? 'bg-gray-900 text-white'
+                                            : 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'
+                                    }`}
+                                >
+                                    {page + 1}
+                                </button>
+                            ))}
+                            <button
+                                type="button"
+                                onClick={() => setCurrentPage((p) => Math.min(totalPages - 1, p + 1))}
+                                disabled={currentPage >= totalPages - 1}
+                                className="min-w-[2.25rem] h-9 px-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:pointer-events-none"
+                            >
+                                다음
+                            </button>
+                        </div>
+                    </nav>
+                )}
             </main>
         </div>
     );


### PR DESCRIPTION
- 기사 목록 페이징 (한 페이지에 10개 -> 12개)
- 종목/퍼블리셔 태그 클릭 후 조회