### PR TITLE
feat: 기사 해시태그 표시 및 전체 태그 목록 구독 관리 기능 추가

### DIFF
--- a/snwa-frontend/src/data/mockArticles.ts
+++ b/snwa-frontend/src/data/mockArticles.ts
@@ -12,6 +12,8 @@ export interface Article {
   summary?: string;
   /** 이미 구매한 번역 언어 코드 (KO, JA, EN, ZH) - 재열람 시 확인창 생략용 */
   purchasedTranslationLanguages?: string[];
+  /** 기사에서 추출된 태그 목록 */
+  tags?: string[];
 }
 
 export const mockArticles: Article[] = [

--- a/snwa-frontend/src/pages/ArticleDetailPage.tsx
+++ b/snwa-frontend/src/pages/ArticleDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useParams, Link, useNavigate } from 'react-router';
-import { ArrowLeft, Bookmark, ChevronDown } from 'lucide-react';
+import { ArrowLeft, Bookmark, ChevronDown, Hash } from 'lucide-react';
 import Header from '../components/Header';
 import ArticleCard from '../components/ArticleCard';
 import { formatDate, Article } from '../data/mockArticles';
@@ -30,6 +30,7 @@ type ApiArticleDetail = {
     angryCount: number;
     userReaction: ReactionType | null;
     purchasedTranslationLanguages?: string[];
+    tags?: string[];
 };
 
 type ReactionCounts = {
@@ -109,6 +110,7 @@ function mapDetailToArticle(d: ApiArticleDetail): Article {
         clickCount: d.clickCount ?? 0,
         summary: d.summary ?? undefined,
         purchasedTranslationLanguages: d.purchasedTranslationLanguages ?? [],
+        tags: d.tags ?? [],
     };
 }
 
@@ -619,6 +621,24 @@ export default function ArticleDetailPage() {
                                 ) : (
                                     <div className="text-gray-700 leading-relaxed whitespace-pre-line">{article.originalContent}</div>
                                 )}
+                            </div>
+                        )}
+
+                        {/* 해시태그 */}
+                        {article.tags && article.tags.length > 0 && (
+                            <div className="mt-6 pt-4 border-t border-gray-100">
+                                <div className="flex flex-wrap gap-2">
+                                    {article.tags.map((tag, idx) => (
+                                        <Link
+                                            key={idx}
+                                            to={`/interests?q=${encodeURIComponent(tag)}`}
+                                            className="inline-flex items-center gap-1 px-3 py-1.5 bg-gray-100 hover:bg-blue-50 hover:text-blue-600 text-sm text-gray-600 rounded-full transition-colors border border-gray-200 hover:border-blue-200"
+                                        >
+                                            <Hash className="w-3.5 h-3.5" />
+                                            {tag}
+                                        </Link>
+                                    ))}
+                                </div>
                             </div>
                         )}
 

--- a/snwa-frontend/src/pages/InterestSettingsPage.tsx
+++ b/snwa-frontend/src/pages/InterestSettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import { useNavigate, Link } from 'react-router';
+import { useNavigate, Link, useSearchParams } from 'react-router';
 import { useAuth } from '../contexts/AuthContext';
 import Header from '../components/Header';
 import { Search, Tag, Check, X, User, Trophy, Users, Award } from 'lucide-react';
@@ -47,13 +47,27 @@ export default function InterestSettingsPage() {
     const [loadingSubscriptions, setLoadingSubscriptions] = useState(true);
     const [togglingId, setTogglingId] = useState<number | null>(null);
 
+    // 전체 태그 상태
+    const [allTargets, setAllTargets] = useState<InterestTarget[]>([]);
+    const [loadingAllTargets, setLoadingAllTargets] = useState(true);
+
+    // URL 쿼리 파라미터 (기사 해시태그 클릭으로 이동 시)
+    const [searchParams] = useSearchParams();
+
     useEffect(() => {
         if (!user) {
             navigate('/login');
             return;
         }
         fetchSubscriptions();
-    }, [user, navigate]);
+        fetchAllTargets();
+
+        // URL 쿼리 파라미터로 검색어 자동 설정
+        const q = searchParams.get('q');
+        if (q) {
+            setSearchQuery(q);
+        }
+    }, [user, navigate, searchParams]);
 
     const fetchSubscriptions = async () => {
         const auth = getAuthHeader();
@@ -96,6 +110,24 @@ export default function InterestSettingsPage() {
             setSearching(false);
         }
     }, []);
+
+    const fetchAllTargets = async () => {
+        const auth = getAuthHeader();
+        if (!auth) return;
+
+        setLoadingAllTargets(true);
+        try {
+            const res = await fetch('/api/targets/all', { headers: auth });
+            if (res.ok) {
+                const data: InterestTarget[] = await res.json();
+                setAllTargets(data);
+            }
+        } catch (error) {
+            console.error('전체 태그 조회 실패:', error);
+        } finally {
+            setLoadingAllTargets(false);
+        }
+    };
 
     // 디바운스 검색
     useEffect(() => {
@@ -146,6 +178,14 @@ export default function InterestSettingsPage() {
     }, {} as Record<InterestType, Subscription[]>);
 
     const displayTypes: InterestType[] = ['PLAYER', 'SPORT', 'TEAM', 'LEAGUE'];
+
+    // 전체 태그를 타입별로 그룹화
+    const groupedAllTargets = allTargets.reduce((acc, target) => {
+        const type = target.type ?? 'OTHER';
+        if (!acc[type]) acc[type] = [];
+        acc[type].push(target);
+        return acc;
+    }, {} as Record<InterestType, InterestTarget[]>);
 
     if (!user) {
         return null;
@@ -260,6 +300,111 @@ export default function InterestSettingsPage() {
                                 )}
                             </div>
                         )}
+
+                        {/* 전체 태그 목록 */}
+                        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+                            <h2 className="text-lg font-bold text-gray-900 mb-4">
+                                전체 태그 목록
+                                {allTargets.length > 0 && (
+                                    <span className="ml-2 text-sm font-normal text-gray-500">
+                                        ({allTargets.length}개)
+                                    </span>
+                                )}
+                            </h2>
+
+                            {loadingAllTargets ? (
+                                <div className="space-y-3">
+                                    {[1, 2, 3].map((i) => (
+                                        <div key={i} className="h-10 bg-gray-100 rounded-lg animate-pulse"></div>
+                                    ))}
+                                </div>
+                            ) : allTargets.length === 0 ? (
+                                <div className="text-center py-8">
+                                    <Tag className="w-10 h-10 text-gray-300 mx-auto mb-2" />
+                                    <p className="text-sm text-gray-500">등록된 태그가 없습니다</p>
+                                </div>
+                            ) : (
+                                <div className="space-y-6">
+                                    {displayTypes.map((type) => {
+                                        const targets = groupedAllTargets[type];
+                                        if (!targets || targets.length === 0) return null;
+                                        const config = TYPE_CONFIG[type as Exclude<InterestType, 'OTHER'>];
+                                        return (
+                                            <div key={type}>
+                                                <div className="flex items-center gap-2 mb-3">
+                                                    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border ${config.color}`}>
+                                                        {config.icon}
+                                                        {config.label}
+                                                    </span>
+                                                    <span className="text-xs text-gray-400">{targets.length}개</span>
+                                                </div>
+                                                <div className="flex flex-wrap gap-2">
+                                                    {targets.map((target) => {
+                                                        const subscribed = isSubscribed(target.id);
+                                                        const toggling = togglingId === target.id;
+                                                        return (
+                                                            <button
+                                                                key={target.id}
+                                                                onClick={() => toggleSubscription(target.id)}
+                                                                disabled={toggling}
+                                                                className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium border transition-all ${subscribed
+                                                                        ? 'bg-gray-900 text-white border-gray-900 hover:bg-gray-800'
+                                                                        : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50 hover:border-gray-300'
+                                                                    }`}
+                                                            >
+                                                                {toggling ? (
+                                                                    <div className="w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full animate-spin"></div>
+                                                                ) : subscribed ? (
+                                                                    <Check className="w-3.5 h-3.5" />
+                                                                ) : null}
+                                                                {target.name}
+                                                            </button>
+                                                        );
+                                                    })}
+                                                </div>
+                                            </div>
+                                        );
+                                    })}
+
+                                    {/* 기타 타입 */}
+                                    {(groupedAllTargets.OTHER?.length ?? 0) > 0 && (
+                                        <div>
+                                            <div className="flex items-center gap-2 mb-3">
+                                                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border bg-gray-100 text-gray-600 border-gray-200">
+                                                    <Tag className="w-3.5 h-3.5" />
+                                                    기타
+                                                </span>
+                                                <span className="text-xs text-gray-400">{groupedAllTargets.OTHER!.length}개</span>
+                                            </div>
+                                            <div className="flex flex-wrap gap-2">
+                                                {groupedAllTargets.OTHER!.map((target) => {
+                                                    const subscribed = isSubscribed(target.id);
+                                                    const toggling = togglingId === target.id;
+                                                    return (
+                                                        <button
+                                                            key={target.id}
+                                                            onClick={() => toggleSubscription(target.id)}
+                                                            disabled={toggling}
+                                                            className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium border transition-all ${subscribed
+                                                                    ? 'bg-gray-900 text-white border-gray-900 hover:bg-gray-800'
+                                                                    : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50 hover:border-gray-300'
+                                                                }`}
+                                                        >
+                                                            {toggling ? (
+                                                                <div className="w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full animate-spin"></div>
+                                                            ) : subscribed ? (
+                                                                <Check className="w-3.5 h-3.5" />
+                                                            ) : null}
+                                                            {target.name}
+                                                        </button>
+                                                    );
+                                                })}
+                                            </div>
+                                        </div>
+                                    )}
+                                </div>
+                            )}
+                        </div>
 
 
                     </div>


### PR DESCRIPTION
-feat: 기사 해시태그 표시 및 전체 태그 목록 구독 관리 기능 추가
- ArticleDetailResponseDto에 tags 필드 추가
- ArticleService.getArticleDetail()에서 ArticleTag 조회 후 응답에 포함
- InterestController에 GET /api/targets/all 엔드포인트 추가
- InterestService에 getAllTargets() 메서드 추가
- Article 인터페이스에 tags 필드 추가
- ArticleDetailPage 본문 아래 해시태그 칩 UI 렌더링
- 해시태그 클릭 시 /interests?q=키워드 로 이동
- InterestSettingsPage에 전체 태그 목록 섹션 추가 (타입별 그룹)
- URL 쿼리 파라미터(q)로 검색어 자동 설정

- fix: 키워드 구독 알림 이벤트 미발행 버그 수정(아직 해결되지 않음)
TranslationService.translateAndSave()에서 키워드 추출 후
ArticleReadyForNotificationEvent가 발행되지 않던 문제 해결
- KeywordExtractionService에 extractTypedKeywords() 메서드 추가
- TranslationService에 ApplicationEventPublisher 주입 및 이벤트 발행 로직 추가 원인: translateAndSave()가 extractKeywordsToList()를 호출해 태그를 저장했지만 이벤트를 발행하지 않았고, 이후 KeywordsTagScheduler는 태그가 이미 존재하여 스킵됨