### PR TITLE
fix: Blue-Green 판별 로직 수정 (컨테이너명 불일치 해결)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -140,7 +140,7 @@ jobs:
             cd /home/ec2-user/final-project-snwa
 
             # 1. 현재 어떤 색상(blue, green)이 떠 있는지 확인 (백엔드 기준)
-            if docker ps --format '{{.Names}}' | grep -q snwa-backend-blue; then
+            if docker ps --format '{{.Names}}' | grep -q snwa-backend-server-blue; then
               NEW=green
               OLD=blue
               NEW_PORT=8081


### PR DESCRIPTION
- 컨테이너 이름 매칭 오류로 인해 Blue-Green 스위칭이 작동하지 않고 Blue 컨테이너에 덮어쓰기 되던 문제 수정
   - Blue->Green->Blue ... 가 아니라 Blue에 계속 덮어 씌고 있었음.