### PR TITLE
fix: 번역된 제목 길이 수정 ('TEXT' 타입으로 수정)

### DIFF
--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/article/entity/Article.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/article/entity/Article.java
@@ -28,6 +28,7 @@ public class Article extends BaseTimeEntity {
     @JoinColumn(name = "user_id")
     private User user; // 글을 등록한 사용자
 
+    @Column(columnDefinition = "TEXT")
     private String title;
 
     @Column(columnDefinition = "LONGTEXT")

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/entity/ArticleTranslation.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/entity/ArticleTranslation.java
@@ -27,6 +27,7 @@ public class ArticleTranslation extends BaseTimeEntity {
     @Column(nullable = false, length = 10)
     private String language; // e.g., "KO", "JA", "EN"
 
+    @Column(columnDefinition = "TEXT")
     private String translatedTitle;
 
     @Column(columnDefinition = "LONGTEXT")


### PR DESCRIPTION
번역된 기사의 제목이 너무 길경우 DB에 저장이 안되는 오류가 있었음. 
@Column(columnDefinition = "TEXT") 추가

-> 정규화 하는 과정에서 누락된걸로 추정