### PR TITLE
fix(security): 강화된 보안 정책 및 접근 제어 적용

### DIFF
--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/global/config/SecurityConfig.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/global/config/SecurityConfig.java
@@ -24,54 +24,62 @@ import java.util.List;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+        private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+        @Bean
+        public PasswordEncoder passwordEncoder() {
+                return new BCryptPasswordEncoder();
+        }
 
-    @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-        // allowCredentials가 true일 때는 와일드카드 사용 불가
-        configuration.setAllowedOriginPatterns(List.of("*")); // 모든 origin 허용 (패턴 사용)
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(List.of("*"));
-        configuration.setAllowCredentials(true);
-        configuration.setExposedHeaders(List.of("Authorization"));
-        configuration.setMaxAge(3600L); // Preflight 요청 캐시 시간
+        @Bean
+        public CorsConfigurationSource corsConfigurationSource() {
+                CorsConfiguration configuration = new CorsConfiguration();
+                // 실제 운영 환경의 프론트엔드 도메인과 로컬 개발 환경만 허용하도록 제한합니다.
+                configuration.setAllowedOriginPatterns(
+                                Arrays.asList("http://localhost:5173", "https://*.surge.sh", "https://*.vercel.app"));
+                configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+                configuration.setAllowedHeaders(List.of("*"));
+                configuration.setAllowCredentials(true);
+                configuration.setExposedHeaders(List.of("Authorization"));
+                configuration.setMaxAge(3600L); // Preflight 요청 캐시 시간
 
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
-    }
+                UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+                source.registerCorsConfiguration("/**", configuration);
+                return source;
+        }
 
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .csrf(AbstractHttpConfigurer::disable)
-                .sessionManagement(session -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**").permitAll()  // 인증 관련 엔드포인트는 허용
-                                .requestMatchers("/api/scheduler/**").permitAll()  // 요약 및 번역테스트용 스케줄러
-                        .requestMatchers("/actuator/**").permitAll() // 모니터링용
-                        .requestMatchers("/error").permitAll()  // 에러 페이지 허용
-                        .requestMatchers("/api/notifications/subscribe").permitAll() // SSE는 토큰 쿼리로 처리
-//                        .requestMatchers("/api/admin/**").hasRole("ADMIN")  // 관리자 전용 실제 서비스용
-                        .requestMatchers("/api/admin/**").permitAll() // 테스트용
-                        //.requestMatchers("/api/orders/**","/api/coins/**","/api/payments/**").permitAll() //결제테스트용
-                                .requestMatchers(HttpMethod.GET, "/api/articles", "/api/articles/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/exp/leaderboard").permitAll()
-                        // 일부 클라이언트가 호출할 수 있는 크롤 경로(실제 실행은 /api/admin/crawler/jobs/{id}/run)
-                        .requestMatchers(HttpMethod.POST, "/api/articles/crawl", "/api/articles/crawl/**").permitAll()
-                        .anyRequest().authenticated()  // 나머지는 인증 필요
-                );
-        
-        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        @Bean
+        public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+                http
+                                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                                .csrf(AbstractHttpConfigurer::disable)
+                                .sessionManagement(session -> session
+                                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                                .authorizeHttpRequests(auth -> auth
+                                                .requestMatchers("/api/auth/**").permitAll() // 인증 관련 엔드포인트 허용
+                                                .requestMatchers("/actuator/health", "/actuator/prometheus").permitAll() // 시스템
+                                                                                                                         // 필수
+                                                                                                                         // 모니터링만
+                                                                                                                         // 허용
+                                                .requestMatchers("/actuator/**").hasRole("ADMIN") // 나머지는 관리자 전용
+                                                .requestMatchers("/api/notifications/subscribe").permitAll() // SSE 토큰
+                                                                                                             // 쿼리 처리
+                                                .requestMatchers("/api/admin/**").hasRole("ADMIN") // 관리자 전용 서비스 보호
+                                                .requestMatchers("/api/scheduler/**").hasRole("ADMIN") // 스케줄러 수동 조작 관리자
+                                                                                                       // 전용
+                                                .requestMatchers(HttpMethod.GET, "/api/articles", "/api/articles/**")
+                                                .permitAll() // 기사 조회 허용
+                                                .requestMatchers(HttpMethod.GET, "/api/exp/leaderboard").permitAll() // 랭킹
+                                                                                                                     // 조회
+                                                                                                                     // 허용
+                                                .requestMatchers(HttpMethod.POST, "/api/articles/crawl",
+                                                                "/api/articles/crawl/**")
+                                                .hasRole("ADMIN") // 크롤링 트리거 관리자 전용 보호
+                                                .anyRequest().authenticated() // 나머지는 인증 필요
+                                );
 
-        return http.build();
-    }
+                http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+                return http.build();
+        }
 }

--- a/snwa-frontend/src/contexts/AuthContext.tsx
+++ b/snwa-frontend/src/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, ReactNode, useEffect } from 'react';
+import { createContext, useContext, useState, ReactNode } from 'react';
 
 interface User {
   email: string;
@@ -29,29 +29,25 @@ interface AuthContextType {
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const [user, setUser] = useState<User | null>(null);
-  const [attendanceRewardJustGiven, setAttendanceRewardJustGiven] = useState(false);
-  const [expGrantInfo, setExpGrantInfo] = useState<ExpGrantInfo | null>(null);
-
-  // Load user from sessionStorage on mount (탭/창 닫으면 로그아웃됨)
-  useEffect(() => {
+  const [user, setUser] = useState<User | null>(() => {
     const token = sessionStorage.getItem('snwa_token');
     const savedUser = sessionStorage.getItem('snwa_user');
 
-
-
-    if (!token || !savedUser) {
-      sessionStorage.removeItem('snwa_user');
-      return;
-    }
-
-    try {
-      setUser(JSON.parse(savedUser));
-    } catch (e) {
-      console.error('Failed to parse user data:', e);
+    if (token && savedUser) {
+      try {
+        return JSON.parse(savedUser);
+      } catch (e) {
+        console.error('Failed to parse user data:', e);
+        sessionStorage.removeItem('snwa_user');
+      }
+    } else if (!token || !savedUser) {
       sessionStorage.removeItem('snwa_user');
     }
-  }, []);
+    return null;
+  });
+
+  const [attendanceRewardJustGiven, setAttendanceRewardJustGiven] = useState(false);
+  const [expGrantInfo, setExpGrantInfo] = useState<ExpGrantInfo | null>(null);
 
   const login = async (email: string, password: string): Promise<boolean> => {
     try {

--- a/snwa-frontend/src/pages/ProfilePage.tsx
+++ b/snwa-frontend/src/pages/ProfilePage.tsx
@@ -138,7 +138,10 @@ export default function ProfilePage() {
                 body: JSON.stringify({ contentType: file.type }),
             });
 
-            if (!presignedRes.ok) throw new Error('Presigned URL 발급 실패');
+            if (!presignedRes.ok) {
+                const errText = await presignedRes.text();
+                throw new Error(`Presigned URL 발급 실패 (${presignedRes.status})`);
+            }
 
             const { presignedUrl, imageUrl } = await presignedRes.json();
 
@@ -149,13 +152,13 @@ export default function ProfilePage() {
                 body: file,
             });
 
-            if (!uploadRes.ok) throw new Error('이미지 업로드 실패');
+            if (!uploadRes.ok) throw new Error(`S3 업로드 실패 (${uploadRes.status})`);
 
             // 3. 이미지 URL 상태 업데이트
             setProfileImageUrl(imageUrl);
-        } catch (error) {
-            console.error('이미지 업로드 실패:', error);
-            alert('이미지 업로드에 실패했습니다.');
+        } catch (error: any) {
+            console.error('이미지 업로드 상세 에러:', error);
+            alert(`업로드 에러 발생: ${error.message}`);
         } finally {
             setUploading(false);
         }


### PR DESCRIPTION
- [CORS] 임의의 도메인(`*`) 허용 패턴을 제한하고, 화이트리스트(localhost, Vercel/Surge 등 프론트 도메인) 방식으로 변경하여 무단 자격 증명 탈취 방지
- [Admin 및 Actuator] 테스트 목적의 `permitAll()`을 모두 제거하고, 관리자 전용 API(`/api/admin/**`)와 민감한 모니터링 엔드포인트(`/actuator/**`)를 `hasRole("ADMIN")`으로 강력하게 보호
- [API 남용 방지] 크롤링 트리거(`/api/articles/crawl/**`) 및 내부 스케줄러 수동 호출 API를 관리자 전용으로 제한하여 리소스 고갈 및 외부 API 과금 위험성 차단
- [모니터링 예외] 클라우드 로드밸런서 및 인프라 상태 체크용 필수 엔드포인트(`health`, `prometheus`)만 명시적으로 개방