### PR TITLE
refactor: ArticleOrchestratorService을 추가하여, 번역서비스를 단일책임 원칙으로 수정

### DIFF
--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/article/controller/ArticleController.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/article/controller/ArticleController.java
@@ -6,7 +6,7 @@ import com.team.snwa.snwabackend.domain.article.dto.request.ArticleCreateRequest
 import com.team.snwa.snwabackend.domain.article.entity.Category;
 import com.team.snwa.snwabackend.domain.article.service.ArticleService;
 import com.team.snwa.snwabackend.domain.translation.dto.response.TranslatedArticleResponseDto;
-import com.team.snwa.snwabackend.domain.translation.service.TranslationService;
+import com.team.snwa.snwabackend.domain.translation.service.ArticleOrchestratorService;
 import com.team.snwa.snwabackend.domain.user.entity.User;
 import com.team.snwa.snwabackend.domain.user.repository.UserRepository;
 import jakarta.validation.Valid;
@@ -28,34 +28,36 @@ public class ArticleController {
 
     private final ArticleService articleService;
     private final UserRepository userRepository;
-    private final TranslationService translationService;
+    private final ArticleOrchestratorService articleOrchestratorService;
 
     /** Principal(이메일)이 있으면 User 조회, 없으면 null — 카테고리별 클릭(ClickLog)용 */
     private User resolveUser(Principal principal) {
-        if (principal == null || principal.getName() == null) return null;
+        if (principal == null || principal.getName() == null)
+            return null;
         return userRepository.findByEmail(principal.getName()).orElse(null);
     }
 
     /**
      * 기사 생성
+     * 
      * @param request 생성 요청 (categoryId, title, content 필수)
-     * @param user 인증된 사용자 (글 작성자)
+     * @param user    인증된 사용자 (글 작성자)
      * @return 생성된 기사 상세 정보
      */
     @PostMapping
     public ResponseEntity<ArticleDetailResponseDto> createArticle(
             @Valid @RequestBody ArticleCreateRequestDto request,
-            @AuthenticationPrincipal User user
-    ) {
+            @AuthenticationPrincipal User user) {
         ArticleDetailResponseDto created = articleService.createArticle(user, request);
         return ResponseEntity.status(org.springframework.http.HttpStatus.CREATED).body(created);
     }
 
     /**
      * 기사 목록 조회
-     * @param categoryId 카테고리 ID (선택적)
+     * 
+     * @param categoryId    카테고리 ID (선택적)
      * @param publisherName 출판사명 (선택적)
-     * @param pageable 페이지 정보 (기본값: size=10, sort=createdDate,desc)
+     * @param pageable      페이지 정보 (기본값: size=10, sort=createdDate,desc)
      * @return 기사 목록
      */
     @GetMapping
@@ -63,9 +65,9 @@ public class ArticleController {
             @RequestParam(required = false) Long categoryId,
             @RequestParam(required = false) String publisherName,
             @PageableDefault(size = 10, sort = "createdDate", direction = org.springframework.data.domain.Sort.Direction.DESC) Pageable pageable,
-            @AuthenticationPrincipal User user
-    ) {
-        Page<ArticleListResponseDto> articles = articleService.getArticleList(categoryId, publisherName, pageable, user);
+            @AuthenticationPrincipal User user) {
+        Page<ArticleListResponseDto> articles = articleService.getArticleList(categoryId, publisherName, pageable,
+                user);
         return ResponseEntity.ok(articles);
     }
 
@@ -87,6 +89,7 @@ public class ArticleController {
 
     /**
      * 기사 상세 조회
+     * 
      * @param id 기사 ID
      * @return 기사 상세 정보
      */
@@ -94,8 +97,7 @@ public class ArticleController {
     public ResponseEntity<ArticleDetailResponseDto> getArticleDetail(
             @PathVariable Long id,
             Principal principal,
-            @RequestParam(required = false, defaultValue = "true") boolean recordView
-    ) {
+            @RequestParam(required = false, defaultValue = "true") boolean recordView) {
         User user = resolveUser(principal);
         ArticleDetailResponseDto article = articleService.getArticleDetail(id, user, recordView);
         return ResponseEntity.ok(article);
@@ -103,21 +105,22 @@ public class ArticleController {
 
     /**
      * 관련 기사 조회 (같은 카테고리의 최신 기사 3개, 현재 기사 제외)
+     * 
      * @param id 현재 기사 ID
      * @return 관련 기사 목록 (최대 3개)
      */
     @GetMapping("/{id}/related")
     public ResponseEntity<List<ArticleListResponseDto>> getRelatedArticles(
             @PathVariable Long id,
-            @AuthenticationPrincipal User user
-    ) {
+            @AuthenticationPrincipal User user) {
         List<ArticleListResponseDto> relatedArticles = articleService.getRelatedArticles(id, user);
         return ResponseEntity.ok(relatedArticles);
     }
 
     /**
      * 기사 검색 (제목 + 내용)
-     * @param keyword 검색어
+     * 
+     * @param keyword  검색어
      * @param pageable 페이지 정보 (기본값: size=10, sort=createdDate,desc)
      * @return 검색된 기사 목록
      */
@@ -125,15 +128,15 @@ public class ArticleController {
     public ResponseEntity<Page<ArticleListResponseDto>> searchArticles(
             @RequestParam String keyword,
             @PageableDefault(size = 10, sort = "createdDate", direction = org.springframework.data.domain.Sort.Direction.DESC) Pageable pageable,
-            @AuthenticationPrincipal User user
-    ) {
+            @AuthenticationPrincipal User user) {
         Page<ArticleListResponseDto> articles = articleService.searchArticles(keyword, pageable, user);
         return ResponseEntity.ok(articles);
     }
 
     /**
      * 제목만 검색
-     * @param keyword 검색어
+     * 
+     * @param keyword  검색어
      * @param pageable 페이지 정보 (기본값: size=10, sort=createdDate,desc)
      * @return 검색된 기사 목록
      */
@@ -141,15 +144,15 @@ public class ArticleController {
     public ResponseEntity<Page<ArticleListResponseDto>> searchByTitle(
             @RequestParam String keyword,
             @PageableDefault(size = 10, sort = "createdDate", direction = org.springframework.data.domain.Sort.Direction.DESC) Pageable pageable,
-            @AuthenticationPrincipal User user
-    ) {
+            @AuthenticationPrincipal User user) {
         Page<ArticleListResponseDto> articles = articleService.searchByTitle(keyword, pageable, user);
         return ResponseEntity.ok(articles);
     }
 
     /**
      * 내용만 검색
-     * @param keyword 검색어
+     * 
+     * @param keyword  검색어
      * @param pageable 페이지 정보 (기본값: size=10, sort=createdDate,desc)
      * @return 검색된 기사 목록
      */
@@ -157,14 +160,14 @@ public class ArticleController {
     public ResponseEntity<Page<ArticleListResponseDto>> searchByContent(
             @RequestParam String keyword,
             @PageableDefault(size = 10, sort = "createdDate", direction = org.springframework.data.domain.Sort.Direction.DESC) Pageable pageable,
-            @AuthenticationPrincipal User user
-    ) {
+            @AuthenticationPrincipal User user) {
         Page<ArticleListResponseDto> articles = articleService.searchByContent(keyword, pageable, user);
         return ResponseEntity.ok(articles);
     }
 
     /**
      * 기사 삭제
+     * 
      * @param id 기사 ID
      * @return 삭제 성공 응답
      */
@@ -187,7 +190,7 @@ public class ArticleController {
         if (user == null) {
             throw new RuntimeException("로그인이 필요합니다.");
         }
-        TranslatedArticleResponseDto response = translationService.getTranslation(user.getId(), id, lang);
+        TranslatedArticleResponseDto response = articleOrchestratorService.getTranslation(user.getId(), id, lang);
         return ResponseEntity.ok(response);
     }
 }

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/article/service/ArticleService.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/article/service/ArticleService.java
@@ -13,7 +13,7 @@ import com.team.snwa.snwabackend.domain.article.repository.ClickLogRepository;
 import com.team.snwa.snwabackend.domain.translation.entity.ArticleTranslation;
 import com.team.snwa.snwabackend.domain.translation.repository.ArticleTranslationRepository;
 import com.team.snwa.snwabackend.domain.translation.repository.TranslationAccessLogRepository;
-import com.team.snwa.snwabackend.domain.translation.service.TranslationService;
+
 import com.team.snwa.snwabackend.domain.user.entity.User;
 import com.team.snwa.snwabackend.domain.user.entity.enums.UserRole;
 import com.team.snwa.snwabackend.domain.wallet.service.CoinTransactionService;
@@ -41,7 +41,7 @@ public class ArticleService {
         private final ReactionService reactionService;
         private final ClickLogRepository clickLogRepository;
         private final CoinTransactionService coinTransactionService;
-        private final TranslationService translationService;
+
         private final TranslationAccessLogRepository translationAccessLogRepository;
         private final ArticleTranslationRepository articleTranslationRepository;
 

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/client/DeepLClient.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/client/DeepLClient.java
@@ -43,16 +43,14 @@ public class DeepLClient implements TranslationClient {
             String translatedContent = "";
 
             if (translatedCombined != null) {
-                // 2. 특수 구분자를 기준으로 다시 분리
-                // 정규식 특수문자([]) 이스케이프 처리 필요
+                // 2. 특수 구분자를 기준으로 제목, 본문 두 덩어리로 나누기 ([0]=제목, [1]=본문)
                 String[] parts = translatedCombined.split("<\\|\\|SMA_SEPARATOR\\|\\|>", 2);
 
                 if (parts.length >= 2) {
                     translatedTitle = parts[0].trim();
                     translatedContent = parts[1].trim();
                 } else {
-                    // 혹시라도 구분자가 변형되었을 경우를 대비해 기존 줄바꿈 로직도 유지하거나,
-                    // 로그를 남기고 전체를 본문에 넣는 식의 처리가 필요할 수 있음
+                    // 혹시라도 구분자가 변형되었을 경우를 대비해 기존 줄바꿈 로직도 유지
                     // 여기서는 일단 제목에 다 들어간 것으로 보임
                     translatedTitle = translatedCombined;
                     translatedContent = "";
@@ -87,7 +85,7 @@ public class DeepLClient implements TranslationClient {
         try {
             // targetLang을 null로 설정하면 자동 감지(KO를 기본값으로 사용)
             String lang = (targetLang == null || targetLang.isBlank()) ? "KO" : targetLang;
-            TextResult result = translator.translateText(text, null, lang);
+            TextResult result = translator.translateText(text, null, lang); // 번역하고 싶은 문장, 언어, 어떤 언어로 번역할 것인가
             return result.getText();
         } catch (Exception e) {
             log.error("텍스트 번역 실패: {}", e.getMessage(), e);

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/controller/TranslationController.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/controller/TranslationController.java
@@ -2,8 +2,8 @@ package com.team.snwa.snwabackend.domain.translation.controller;
 
 import com.team.snwa.snwabackend.domain.translation.dto.response.SummaryResponseDto;
 import com.team.snwa.snwabackend.domain.translation.dto.response.TranslatedArticleResponseDto;
+import com.team.snwa.snwabackend.domain.translation.service.ArticleOrchestratorService;
 import com.team.snwa.snwabackend.domain.translation.service.SummaryService;
-import com.team.snwa.snwabackend.domain.translation.service.TranslationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class TranslationController {
 
-    private final TranslationService translationService;
+    private final ArticleOrchestratorService articleOrchestratorService;
     private final SummaryService summaryService;
 
     @PostMapping("/translation/test")
@@ -23,7 +23,7 @@ public class TranslationController {
             @PathVariable Long articleId) {
         log.info("번역 요청 받음: articleId={}", articleId);
 
-        TranslatedArticleResponseDto response = translationService.translateArticle(articleId);
+        TranslatedArticleResponseDto response = articleOrchestratorService.translateArticle(articleId);
 
         return ResponseEntity.ok(response);
     }

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/scheduler/TranslationScheduler.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/scheduler/TranslationScheduler.java
@@ -2,7 +2,7 @@ package com.team.snwa.snwabackend.domain.translation.scheduler;
 
 import com.team.snwa.snwabackend.domain.article.entity.Article;
 import com.team.snwa.snwabackend.domain.article.repository.ArticleRepository;
-import com.team.snwa.snwabackend.domain.translation.service.TranslationService;
+import com.team.snwa.snwabackend.domain.translation.service.ArticleOrchestratorService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -21,7 +21,7 @@ import java.util.List;
 public class TranslationScheduler {
 
     private final ArticleRepository articleRepository;
-    private final TranslationService translationService;
+    private final ArticleOrchestratorService articleOrchestratorService;
 
     private static final int BATCH_SIZE = 2; // 한 번에 처리할 기사 개수
     private static final long API_DELAY_MS = 4000;
@@ -50,7 +50,7 @@ public class TranslationScheduler {
             for (Article article : articles) {
                 try {
                     log.debug("기사 번역 시작: articleId={}", article.getId());
-                    translationService.translateArticle(article.getId());
+                    articleOrchestratorService.translateArticle(article.getId());
                     Thread.sleep(API_DELAY_MS);
                 } catch (Exception e) {
                     failCount++;

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/service/ArticleOrchestratorService.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/service/ArticleOrchestratorService.java
@@ -1,0 +1,106 @@
+package com.team.snwa.snwabackend.domain.translation.service;
+
+import com.team.snwa.snwabackend.domain.article.entity.Article;
+import com.team.snwa.snwabackend.domain.article.repository.ArticleRepository;
+import com.team.snwa.snwabackend.domain.translation.dto.response.TranslatedArticleResponseDto;
+import com.team.snwa.snwabackend.domain.translation.entity.ArticleTranslation;
+import com.team.snwa.snwabackend.domain.translation.entity.TranslationAccessLog;
+import com.team.snwa.snwabackend.domain.translation.repository.TranslationAccessLogRepository;
+import com.team.snwa.snwabackend.domain.user.entity.User;
+import com.team.snwa.snwabackend.domain.user.entity.enums.UserRole;
+import com.team.snwa.snwabackend.domain.user.repository.UserRepository;
+import com.team.snwa.snwabackend.domain.wallet.service.WalletTransactionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ArticleOrchestratorService {
+
+    private final TranslationService translationService;
+    private final SummaryService summaryService;
+    private final KeywordExtractionService keywordExtractionService;
+
+    // 권한 체크 및 접근 로그, 결제를 위한 의존성
+    private final TranslationAccessLogRepository translationAccessLogRepository;
+    private final WalletTransactionService walletTransactionService;
+    private final UserRepository userRepository;
+    private final ArticleRepository articleRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public TranslatedArticleResponseDto getTranslation(Long userId, Long articleId, String language) {
+        String targetLang = (language == null || language.isBlank()) ? "KO" : language.toUpperCase();
+
+        // 1. 코인 결제 및 권한 체크
+        checkAccessAndSpendCoin(userId, articleId, targetLang);
+
+        return processPipeline(articleId, targetLang);
+    }
+
+    @Deprecated
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public TranslatedArticleResponseDto translateArticle(Long articleId) {
+        // 스케줄러 등에서 userId 없이 호출용 (기본 KO 번역)
+        return processPipeline(articleId, "KO");
+    }
+
+    private TranslatedArticleResponseDto processPipeline(Long articleId, String targetLang) {
+        // 2. 번역 (필요시 내부에서 DB 확인 후 API 번역 및 저장)
+        ArticleTranslation translation = translationService.getOrTranslate(articleId, targetLang);
+
+        // 3. 요약 (필요시 내부에서 DB 확인 후 API 요약 및 저장)
+        String summary = summaryService.summarizeIfNeeded(translation, targetLang);
+
+        // 4. 키워드 추출 (필요시 내부에서 DB 확인 후 API 추출 및 저장)
+        List<String> tags = keywordExtractionService.extractKeywordsIfNeeded(translation, targetLang);
+
+        // 5. 조립 후 반환
+        return TranslatedArticleResponseDto.builder()
+                .title(translation.getArticle().getTitle())
+                .content(translation.getArticle().getContent())
+                .translatedTitle(translation.getTranslatedTitle())
+                .translatedContent(translation.getTranslatedContent())
+                .summary(summary)
+                .tags(tags)
+                .authorName(translation.getArticle().getAuthorName())
+                .publisherName(translation.getArticle().getPublisherName())
+                .originalUrl(translation.getArticle().getOriginalUrl())
+                .build();
+    }
+
+    private void checkAccessAndSpendCoin(Long userId, Long articleId, String targetLang) {
+        if (userId == null)
+            return;
+
+        boolean hasAccess = translationAccessLogRepository.existsByUserIdAndArticleIdAndLanguage(userId, articleId,
+                targetLang);
+        if (hasAccess)
+            return;
+
+        User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        if (user.getRole() != UserRole.ADMIN) {
+            Article article = articleRepository.findById(articleId)
+                    .orElseThrow(() -> new RuntimeException("기사를 찾을 수 없습니다."));
+
+            // 코인 차감 (1코인)
+            String externalRef = "TRANS_" + articleId + "_" + targetLang + "_" + System.currentTimeMillis();
+            walletTransactionService.spend(user, 1L, externalRef);
+
+            // 접근 로그 저장
+            TranslationAccessLog logInfo = TranslationAccessLog.builder()
+                    .user(user)
+                    .article(article)
+                    .language(targetLang)
+                    .build();
+            translationAccessLogRepository.save(logInfo);
+        }
+    }
+}

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/service/KeywordExtractionService.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/service/KeywordExtractionService.java
@@ -57,6 +57,7 @@ public class KeywordExtractionService {
         return CompletableFuture.completedFuture(null);
     }
 
+    // 번역-요약하기 버튼을 눌렀을 때 실행
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void extractKeywords(Long articleId, String targetLang) {
         log.info("기사 키워드 추출 시작: articleId={}, lang={}", articleId, targetLang);
@@ -71,7 +72,7 @@ public class KeywordExtractionService {
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(() -> new RuntimeException("기사를 찾을 수 없습니다: id=" + articleId));
 
-        // 2. 번역 데이터 우선 조회 -> 없으면 기사 원문 조회 (Fallback)
+        // 2. 번역 데이터 우선 조회 -> 없으면 기사 원문 조회 -> contentToExtract=번역된 본문 or 원본 본문
         String contentToExtract = articleTranslationRepository.findByArticleIdAndLanguage(articleId, targetLang)
                 .map(ArticleTranslation::getTranslatedContent)
                 .orElseGet(() -> {
@@ -109,6 +110,42 @@ public class KeywordExtractionService {
                         typedKeywords));
     }
 
+    @Transactional
+    public List<String> extractKeywordsIfNeeded(ArticleTranslation translation, String targetLang) {
+        List<String> tags = articleTagRepository
+                .findByArticleIdAndLanguage(translation.getArticle().getId(), targetLang)
+                .stream()
+                .map(ArticleTag::getTagName)
+                .toList();
+
+        if (!tags.isEmpty()) {
+            return tags;
+        }
+
+        try {
+            tags = extractKeywordsToList(translation.getTranslatedContent(), targetLang);
+            if (!tags.isEmpty()) {
+                for (String tagName : tags) {
+                    articleTagRepository.save(ArticleTag.builder()
+                            .article(translation.getArticle())
+                            .tagName(tagName)
+                            .language(targetLang)
+                            .build());
+                }
+            }
+            return tags;
+        } catch (com.team.snwa.snwabackend.global.exception.CustomException e) {
+            if (e.getErrorCode() == com.team.snwa.snwabackend.global.exception.ErrorCode.AI_API_QUOTA_EXCEEDED) {
+                throw e;
+            }
+            log.error("태그기능 실패(Skipped): {}", e.getMessage());
+            return new ArrayList<>();
+        } catch (Exception e) {
+            log.error("태그기능 실패(Skipped): {}", e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+
     public List<String> extractKeywordsToList(String translatedContent, String targetLang) {
         Map<String, InterestType> typedKeywords = extractKeywordsFromContent(translatedContent, targetLang);
         return new ArrayList<>(typedKeywords.keySet());
@@ -125,7 +162,8 @@ public class KeywordExtractionService {
                 languageName);
         ChatClient chatClient = chatClientBuilder.build();
         try {
-            String keywordsResponse = chatClient.prompt(prompt).call().content();
+            String keywordsResponse = chatClient.prompt(prompt).call().content(); // "손흥민(Player), 토트넘(Team),
+                                                                                  // 프리미어리그(League), 축구(Sport)"
             return parseTypedKeywords(keywordsResponse);
         } catch (Exception e) {
             log.error("AI 키워드 추출 중 오류 발생: {}", e.getMessage(), e);
@@ -140,7 +178,7 @@ public class KeywordExtractionService {
     }
 
     /**
-     * AI 응답에서 "키워드(타입)" 형식을 파싱하여 Map으로 반환
+     * AI 응답에서 "키워드(타입)" 형식을 파싱하여 Map으로 반환(key, value 형식)
      * 예: "호날두(Player), 맨유(Team)" -> {호날두=PLAYER, 맨유=TEAM}
      */
     private Map<String, InterestType> parseTypedKeywords(String keywordsResponse) {

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/service/SummaryService.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/service/SummaryService.java
@@ -56,6 +56,29 @@ public class SummaryService {
                 .build();
     }
 
+    @Transactional
+    public String summarizeIfNeeded(ArticleTranslation translation, String targetLang) {
+        if (translation.getSummary() != null && !translation.getSummary().trim().isEmpty()) {
+            return translation.getSummary();
+        }
+
+        try {
+            String summary = generateSummary(translation.getTranslatedContent(), targetLang);
+            translation.updateSummary(summary);
+            articleTranslationRepository.save(translation);
+            return summary;
+        } catch (com.team.snwa.snwabackend.global.exception.CustomException e) {
+            if (e.getErrorCode() == com.team.snwa.snwabackend.global.exception.ErrorCode.AI_API_QUOTA_EXCEEDED) {
+                throw e;
+            }
+            log.error("요약기능 실패(Skipped): {}", e.getMessage());
+            return null;
+        } catch (Exception e) {
+            log.error("요약기능 실패(Skipped): {}", e.getMessage());
+            return null;
+        }
+    }
+
     /**
      * 번역된 기사 내용을 지정된 언어로 요약합니다.
      *
@@ -97,7 +120,8 @@ public class SummaryService {
 
     private String loadPromptTemplate() {
         try {
-            Resource resource = resourceLoader.getResource("classpath:prompts/summary-prompt.txt");
+            Resource resource = resourceLoader.getResource("classpath:prompts/summary-prompt.txt"); // classpath =
+                                                                                                    // src/main/resources
             return StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8);
         } catch (Exception e) {
             log.error("프롬프트 템플릿 로드 실패: {}", e.getMessage(), e);

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/service/TranslationService.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/service/TranslationService.java
@@ -1,307 +1,64 @@
 package com.team.snwa.snwabackend.domain.translation.service;
 
 import com.team.snwa.snwabackend.domain.article.entity.Article;
-import com.team.snwa.snwabackend.domain.article.entity.ArticleTag;
 import com.team.snwa.snwabackend.domain.article.repository.ArticleRepository;
-import com.team.snwa.snwabackend.domain.article.repository.ArticleTagRepository;
 import com.team.snwa.snwabackend.domain.translation.client.TranslationClient;
 import com.team.snwa.snwabackend.domain.translation.dto.request.CrawledArticleRequestDto;
 import com.team.snwa.snwabackend.domain.translation.dto.response.TranslatedArticleResponseDto;
 import com.team.snwa.snwabackend.domain.translation.entity.ArticleTranslation;
-import com.team.snwa.snwabackend.domain.translation.entity.TranslationAccessLog;
 import com.team.snwa.snwabackend.domain.translation.repository.ArticleTranslationRepository;
-import com.team.snwa.snwabackend.domain.translation.repository.TranslationAccessLogRepository;
-import com.team.snwa.snwabackend.domain.user.entity.User;
-import com.team.snwa.snwabackend.domain.user.entity.enums.UserRole;
-import com.team.snwa.snwabackend.domain.user.repository.UserRepository;
-import com.team.snwa.snwabackend.domain.wallet.service.WalletTransactionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class TranslationService {
 
     private final TranslationClient translationClient;
     private final ArticleRepository articleRepository;
     private final ArticleTranslationRepository articleTranslationRepository;
-    private final SummaryService summaryService;
-    private final KeywordExtractionService keywordExtractionService;
-    private final TranslationAccessLogRepository translationAccessLogRepository;
-    private final WalletTransactionService walletTransactionService;
-    private final UserRepository userRepository;
-    private final ArticleTagRepository articleTagRepository;
 
-    // 번역본을 볼 수 있는 권한 체크
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public TranslatedArticleResponseDto getTranslation(Long userId, Long articleId, String language) {
-
-        // 언어 기본값 KO
-        String targetLang = (language == null || language.isBlank()) ? "KO" : language.toUpperCase();
-
-        // 1. 접근 권한 확인 (기사 + 언어 단위)
-        boolean hasAccess = translationAccessLogRepository.existsByUserIdAndArticleIdAndLanguage(userId, articleId,
-                targetLang);
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
-
-        if (!hasAccess && user.getRole() != UserRole.ADMIN) {
-            // 2. 권한 없으면 코인 차감
-            Article article = articleRepository.findById(articleId)
-                    .orElseThrow(() -> new RuntimeException("기사를 찾을 수 없습니다."));
-
-            // 코인 차감 (1코인)
-            String externalRef = "TRANS_" + articleId + "_" + targetLang + "_" + System.currentTimeMillis();
-            walletTransactionService.spend(user, 1L, externalRef);
-
-            // 접근 로그 저장
-            TranslationAccessLog log = TranslationAccessLog.builder()
-                    .user(user)
-                    .article(article)
-                    .language(targetLang)
-                    .build();
-            translationAccessLogRepository.save(log);
-        }
-
-        // 3. 번역 데이터 조회 또는 생성
+    /**
+     * DB에서 번역본을 조회하고, 없으면 외부 AI API를 호출하여 번역 후 저장합니다.
+     */
+    @Transactional
+    public ArticleTranslation getOrTranslate(Long articleId, String targetLang) {
         return articleTranslationRepository.findByArticleIdAndLanguage(articleId, targetLang)
-                .map(t -> {
-                    boolean updated = false;
-
-                    // 요약이 비어있으면 채워넣기
-                    String summary = t.getSummary();
-                    if (summary == null || summary.isBlank()) {
-                        try {
-                            summary = summaryService.generateSummary(t.getTranslatedContent(), targetLang);
-                            t.updateSummary(summary);
-                            updated = true;
-                        } catch (Exception e) {
-                            log.error("요약기능 실패(Skipped): {}", e.getMessage());
-                        }
-                    }
-
-                    // [수정] 태그 조회: ArticleTag 테이블에서 가져옴
-                    List<String> tags = articleTagRepository.findByArticleIdAndLanguage(articleId, targetLang)
-                            .stream()
-                            .map(ArticleTag::getTagName)
-                            .toList();
-
-                    // 태그가 없으면 새로 추출 (보수 로직)
-                    if (tags.isEmpty()) {
-                        try {
-                            tags = keywordExtractionService.extractKeywordsToList(t.getTranslatedContent(), targetLang);
-                            if (!tags.isEmpty()) {
-                                // ArticleTag 테이블에 저장
-                                for (String tagName : tags) {
-                                    articleTagRepository.save(ArticleTag.builder()
-                                            .article(t.getArticle())
-                                            .tagName(tagName)
-                                            .language(targetLang)
-                                            .build());
-                                }
-                            }
-                        } catch (Exception e) {
-                            log.error("태그기능 실패(Skipped): {}", e.getMessage());
-                        }
-                    }
-
-                    if (updated) {
-                        articleTranslationRepository.save(t);
-                    }
-
-                    return TranslatedArticleResponseDto.builder()
-                            .title(t.getArticle().getTitle())
-                            .content(t.getArticle().getContent())
-                            .translatedTitle(t.getTranslatedTitle())
-                            .translatedContent(t.getTranslatedContent())
-                            .summary(summary)
-                            .tags(tags)
-                            .authorName(t.getArticle().getAuthorName())
-                            .publisherName(t.getArticle().getPublisherName())
-                            .originalUrl(t.getArticle().getOriginalUrl())
-                            .build();
-                })
                 .orElseGet(() -> {
-                    // 없으면 새로 번역 요청
-                    return translateAndSave(articleId, targetLang);
+                    log.info("기사 번역 요청 시작: articleId={}, lang={}", articleId, targetLang);
+                    Article article = articleRepository.findById(articleId)
+                            .orElseThrow(() -> new RuntimeException("기사를 찾을 수 없습니다: " + articleId));
+
+                    CrawledArticleRequestDto request = CrawledArticleRequestDto.builder()
+                            .title(article.getTitle())
+                            .content(article.getContent())
+                            .authorName(article.getAuthorName())
+                            .publisherName(article.getPublisherName())
+                            .originalUrl(article.getOriginalUrl())
+                            .build();
+
+                    // 외부 API 호출
+                    TranslatedArticleResponseDto response = translationClient.translate(request, targetLang);
+
+                    ArticleTranslation translation = ArticleTranslation.builder()
+                            .article(article)
+                            .language(targetLang)
+                            .translatedTitle(response.getTranslatedTitle())
+                            .translatedContent(response.getTranslatedContent())
+                            .build();
+
+                    return articleTranslationRepository.save(translation);
                 });
     }
 
-    // 실제 번역 API 호출 및 저장
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public TranslatedArticleResponseDto translateAndSave(Long articleId, String targetLang) {
-
-        // 1. 이미 번역된 데이터가 DB에 있는지 확인 (API 호출 방지)
-        var existingTranslation = articleTranslationRepository.findByArticleIdAndLanguage(articleId, targetLang);
-
-        if (existingTranslation.isPresent()) {
-            ArticleTranslation t = existingTranslation.get();
-            boolean updated = false; // 변경 사항이 있는지 체크
-            // 1-1. 요약이 비어있으면 채워넣기 (보수 로직)
-            if (t.getSummary() == null || t.getSummary().isBlank()) {
-                try {
-                    String summary = summaryService.generateSummary(t.getTranslatedContent(), targetLang);
-                    t.updateSummary(summary);
-                    updated = true;
-                    log.info("기존 번역본에 요약이 없어 새로 생성했습니다: articleId={}", articleId);
-                } catch (Exception e) {
-                    log.error("요약 생성 실패(Skipped): {}", e.getMessage());
-                }
-            }
-
-            // 1-2. 태그가 비어있으면 채워넣기 (보수 로직)
-            // [수정] ArticleTag 테이블에서 조회
-            List<String> tags = articleTagRepository.findByArticleIdAndLanguage(articleId, targetLang)
-                    .stream()
-                    .map(ArticleTag::getTagName)
-                    .toList();
-
-            if (tags.isEmpty()) {
-                try {
-                    // 태그가 없으면 새로 추출
-                    tags = keywordExtractionService.extractKeywordsToList(t.getTranslatedContent(), targetLang);
-                    if (!tags.isEmpty()) {
-                        // ArticleTag 테이블에 저장
-                        for (String tagName : tags) {
-                            articleTagRepository.save(ArticleTag.builder()
-                                    .article(t.getArticle())
-                                    .tagName(tagName)
-                                    .language(targetLang)
-                                    .build());
-                        }
-                    }
-                } catch (Exception e) {
-                    log.error("태그기능 실패(Skipped): {}", e.getMessage());
-                }
-            }
-
-            // 변경사항이 있으면 저장
-            if (updated) {
-                articleTranslationRepository.save(t);
-            }
-
-            log.info("최종 데이터 반환 (DB 캐시 사용): articleId={}, lang={}", articleId, targetLang);
-            return TranslatedArticleResponseDto.builder()
-                    .title(t.getArticle().getTitle())
-                    .content(t.getArticle().getContent())
-                    .translatedTitle(t.getTranslatedTitle())
-                    .translatedContent(t.getTranslatedContent())
-                    .summary(t.getSummary())
-                    .tags(tags)
-                    .authorName(t.getArticle().getAuthorName())
-                    .publisherName(t.getArticle().getPublisherName())
-                    .originalUrl(t.getArticle().getOriginalUrl())
-                    .build();
-        }
-
-        log.info("기사 번역/요약/태그 요청 시작: articleId={}, lang={}", articleId, targetLang);
-        Article article = articleRepository.findById(articleId)
-                .orElseThrow(() -> new RuntimeException("기사를 찾을 수 없습니다: " + articleId));
-
-        CrawledArticleRequestDto request = CrawledArticleRequestDto.builder()
-                .title(article.getTitle())
-                .content(article.getContent())
-                .authorName(article.getAuthorName())
-                .publisherName(article.getPublisherName())
-                .originalUrl(article.getOriginalUrl())
-                .build();
-
-        // 1. 번역 실행
-        TranslatedArticleResponseDto response = translationClient.translate(request, targetLang);
-        String translatedContent = response.getTranslatedContent();
-
-        // 2. 요약 생성 (번역 언어와 동일한 언어로 요약)
-        String summary = null;
-        try {
-            if (translatedContent != null && !translatedContent.trim().isEmpty()) {
-                summary = summaryService.generateSummary(translatedContent, targetLang);
-            } else {
-                log.warn("번역된 내용이 비어있어 요약을 생략합니다. articleId={}", articleId);
-            }
-        } catch (Exception e) {
-            if (e instanceof com.team.snwa.snwabackend.global.exception.CustomException &&
-                    ((com.team.snwa.snwabackend.global.exception.CustomException) e)
-                            .getErrorCode() == com.team.snwa.snwabackend.global.exception.ErrorCode.AI_API_QUOTA_EXCEEDED) {
-                throw e;
-            }
-            log.error("요약 생성 실패: {}", e.getMessage());
-        }
-
-        // 3. 키워드 추출
-        List<String> tags = new ArrayList<>();
-        try {
-            // DB에 해당 언어의 태그가 이미 있는지 조회 (크롤링 시 생성된 KO 태그 등 재사용)
-            List<String> existingTags = articleTagRepository.findByArticleIdAndLanguage(articleId, targetLang)
-                    .stream()
-                    .map(ArticleTag::getTagName)
-                    .toList();
-
-            if (!existingTags.isEmpty()) {
-                log.info("기존 태그 재사용: articleId={}, lang={}", articleId, targetLang);
-                tags = existingTags;
-            } else {
-                tags = keywordExtractionService.extractKeywordsToList(translatedContent, targetLang);
-                if (!tags.isEmpty()) {
-                    if (!articleTagRepository.existsByArticleIdAndLanguage(articleId, targetLang)) {
-                        for (String tagName : tags) {
-                            articleTagRepository.save(ArticleTag.builder()
-                                    .article(article)
-                                    .tagName(tagName)
-                                    .language(targetLang)
-                                    .build());
-                        }
-                    }
-                }
-            }
-        } catch (Exception e) {
-            if (e instanceof com.team.snwa.snwabackend.global.exception.CustomException &&
-                    ((com.team.snwa.snwabackend.global.exception.CustomException) e)
-                            .getErrorCode() == com.team.snwa.snwabackend.global.exception.ErrorCode.AI_API_QUOTA_EXCEEDED) {
-                throw e;
-            }
-            log.error("키워드 추출 실패: {}", e.getMessage());
-        }
-
-        // 4. 저장 (ArticleTranslation 엔티티)
-        ArticleTranslation translation = ArticleTranslation.builder()
-                .article(article)
-                .language(targetLang)
-                .translatedTitle(response.getTranslatedTitle())
-                .translatedContent(translatedContent)
-                .summary(summary)
-                .build();
-
-        articleTranslationRepository.save(translation);
-
-        log.info("번역/요약/태그 처리 완료: articleId={}, lang={}", articleId, targetLang);
-
-        // 5. 응답 반환
-        return TranslatedArticleResponseDto.builder()
-                .title(article.getTitle())
-                .content(article.getContent())
-                .translatedTitle(response.getTranslatedTitle())
-                .translatedContent(translatedContent)
-                .authorName(article.getAuthorName())
-                .publisherName(article.getPublisherName())
-                .originalUrl(article.getOriginalUrl())
-                .summary(summary)
-                .tags(tags)
-                .build();
-    }
-
-    @Deprecated
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public TranslatedArticleResponseDto translateArticle(Long articleId) {
-        return translateAndSave(articleId, "KO");
+    /**
+     * 외부 AI API(또는 번역 API)를 호출하여 순수하게 번역만 수행합니다.
+     */
+    public TranslatedArticleResponseDto translateOnly(CrawledArticleRequestDto request, String targetLang) {
+        log.info("순수 번역 API 호출 시작: 언어={}", targetLang);
+        return translationClient.translate(request, targetLang);
     }
 }

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/global/config/SecurityConfig.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/global/config/SecurityConfig.java
@@ -36,7 +36,8 @@ public class SecurityConfig {
                 CorsConfiguration configuration = new CorsConfiguration();
                 // 실제 운영 환경의 프론트엔드 도메인과 로컬 개발 환경만 허용하도록 제한합니다.
                 configuration.setAllowedOriginPatterns(
-                                Arrays.asList("http://localhost:5173", "https://*.surge.sh", "https://*.vercel.app","http://3.39.237.24:70"));
+                                Arrays.asList("http://localhost:5173", "http://localhost:70", "https://*.surge.sh",
+                                                "https://*.vercel.app", "http://3.39.237.24:70"));
                 configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
                 configuration.setAllowedHeaders(List.of("*"));
                 configuration.setAllowCredentials(true);


### PR DESCRIPTION
## 📌 변경 사항 ##
기존  TranslationService에 집중되어 있던 역할들을 분리하여 단일 책임 원칙을 준수하도록 아키텍쳐를 리팩토링 진행

- **문제점:** 기존 TranslationService는 번역뿐만 아니라 요약, 태그 추출 등 다른 도메인의 서비스들을 직접 호출하고 있었다.

- **해결책:**
1. 전체 서비스(번역, 요약, 태그 추출)을 제어하고 호출하는 ArticleOrchestratorService 추가.
2. 이를 통해 TranslationService는 오직 번역 로직만 담당하도록 수정