### PR TITLE
fix: 관리자 페이지 내 번역 전 기사의 태그 미노출 문제 해결

### DIFF
--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/article/dto/response/AdminArticleTranslationSummaryTagsResponseDto.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/article/dto/response/AdminArticleTranslationSummaryTagsResponseDto.java
@@ -10,6 +10,7 @@ import java.util.List;
 public class AdminArticleTranslationSummaryTagsResponseDto {
 
     private final Long id;
+    private final String originalTitle;
 
     // 번역 정보 리스트 (KO, JA, ZH 등)
     private final List<TranslationDetail> translations;

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/user/service/AdminService.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/user/service/AdminService.java
@@ -6,7 +6,7 @@ import com.team.snwa.snwabackend.domain.article.entity.Article;
 import com.team.snwa.snwabackend.domain.comment.entity.Comment;
 import com.team.snwa.snwabackend.domain.comment.repository.CommentRepository;
 import com.team.snwa.snwabackend.domain.translation.entity.ArticleTranslation;
-import com.team.snwa.snwabackend.domain.translation.repository.ArticleTranslationRepository;    //
+import com.team.snwa.snwabackend.domain.translation.repository.ArticleTranslationRepository; //
 import com.team.snwa.snwabackend.domain.user.dto.response.AdminUserCommentResponse;
 import com.team.snwa.snwabackend.domain.article.entity.ArticleTag;
 import com.team.snwa.snwabackend.domain.article.repository.ArticleRepository;
@@ -143,18 +143,16 @@ public class AdminService {
 
         // 삭제되지 않은 글만 조회 (등록 날짜 내림차순)
         List<Article> articles = articleRepository.findAllByDeletedAtIsNull(
-            Sort.by("createdDate").descending()
-        );
+                Sort.by("createdDate").descending());
 
         // DTO로 변환
         return articles.stream()
                 .map(article -> new AdminArticleListResponse(
-                    article.getId(),
-                    article.getTitle(),
-                    article.getUser() != null ? article.getUser().getNickname() :
-                        (article.getAuthorName() != null ? article.getAuthorName() : "알 수 없음"),
-                    article.getCreatedDate()
-                ))
+                        article.getId(),
+                        article.getTitle(),
+                        article.getUser() != null ? article.getUser().getNickname()
+                                : (article.getAuthorName() != null ? article.getAuthorName() : "알 수 없음"),
+                        article.getCreatedDate()))
                 .collect(Collectors.toList());
     }
 
@@ -221,27 +219,42 @@ public class AdminService {
 
         return articles.stream().map(article -> {
             List<ArticleTranslation> translations = articleTranslationRepository.findAllByArticleId(article.getId());
+            List<ArticleTag> allTags = articleTagRepository.findAllByArticleId(article.getId());
 
-            List<AdminArticleTranslationSummaryTagsResponseDto.TranslationDetail> details = translations.stream().map(t -> {
-                List<String> tags = articleTagRepository.findAllByArticleId(article.getId())
-                        .stream()
-                        .filter(tag -> t.getLanguage().equals(tag.getLanguage())) // 언어 일치하는 것만
-                        .map(ArticleTag::getTagName)
-                        .collect(Collectors.toList());
-                return new AdminArticleTranslationSummaryTagsResponseDto.TranslationDetail(
-                        t.getLanguage(),
-                        t.getTranslatedTitle(),
-                        t.getTranslatedContent(),
-                        t.getSummary(),
-                        tags
-                );
-            }).collect(Collectors.toList());
+            // 모든 관련 언어 추출 (번역이 있거나 태그가 있는 경우)
+            java.util.Set<String> languages = new java.util.TreeSet<>();
+            translations.forEach(t -> languages.add(t.getLanguage()));
+            allTags.forEach(tag -> languages.add(tag.getLanguage()));
 
-            // 요청하신 5개 필드(ID, 번역제목, 번역내용, 요약, 태그) 반환
+            // 만약 아무 정보도 없으면 기본적으로 "KO"라도 보여주기 위해 추가 (관리자가 번역 시작할 수 있게)
+            if (languages.isEmpty()) {
+                languages.add("KO");
+            }
+
+            List<AdminArticleTranslationSummaryTagsResponseDto.TranslationDetail> details = languages.stream()
+                    .map(lang -> {
+                        ArticleTranslation translation = translations.stream()
+                                .filter(t -> t.getLanguage().equals(lang))
+                                .findFirst()
+                                .orElse(null);
+
+                        List<String> tags = allTags.stream()
+                                .filter(tag -> tag.getLanguage().equals(lang))
+                                .map(ArticleTag::getTagName)
+                                .collect(Collectors.toList());
+
+                        return new AdminArticleTranslationSummaryTagsResponseDto.TranslationDetail(
+                                lang,
+                                translation != null ? translation.getTranslatedTitle() : null,
+                                translation != null ? translation.getTranslatedContent() : null,
+                                translation != null ? translation.getSummary() : null,
+                                tags);
+                    }).collect(Collectors.toList());
+
             return new AdminArticleTranslationSummaryTagsResponseDto(
                     article.getId(),
-                    details
-                );
-            }).collect(Collectors.toList());
+                    article.getTitle(), // 원본 제목 추가
+                    details);
+        }).collect(Collectors.toList());
     }
 }

--- a/snwa-frontend/src/components/admin/TranslationManager.tsx
+++ b/snwa-frontend/src/components/admin/TranslationManager.tsx
@@ -12,6 +12,7 @@ type TranslationDetail = {
 
 type AdminArticleGroup = {
     id: number;
+    originalTitle: string;    // 원본 제목 (번역 전용)
     translations: TranslationDetail[];
 };
 
@@ -179,7 +180,11 @@ function TranslationRow({ group, onDetailView }: { group: AdminArticleGroup, onD
                 </div>
             </td>
             <td className="px-6 py-4 font-medium align-top">
-                {current.translatedTitle}
+                {current.translatedTitle || (
+                    <span className="text-gray-400 italic font-normal text-xs">
+                        [Original] {group.originalTitle}
+                    </span>
+                )}
             </td>
             <td className="px-6 py-4 text-gray-600 line-clamp-2 mt-4 align-top text-xs leading-relaxed">
                 {current.summary ? (current.summary.length > 100 ? current.summary.substring(0, 100) + '...' : current.summary) : '-'}


### PR DESCRIPTION
기사를 크롤링해올 때 한국어 태그를 자동으로 추출하게 되는데, 
그때 관리자 페이지에서 해당 기사와 태그가 노출되지 않던 문제를 해결