### PR TITLE
feat: Swagger UI 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ inspect_output*.txt
 *.log
 
 .skills/
+
+.CLAUDE.md
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+SNWA is a multilingual sports news platform with:
+- **Backend**: Spring Boot 3.4 (Java 21) REST API
+- **Frontend**: React 18 + TypeScript + Vite
+- **AI Pipeline**: DeepL translation + Gemini 2.5-flash for summarization/tagging
+- **Deployment**: Blue-green Docker deployment via Nginx on EC2
+
+## Commands
+
+### Backend (`snwa-backend/`)
+```bash
+./gradlew clean build        # Full build
+./gradlew test               # Run all tests
+./gradlew test --tests "com.team.snwa.snwabackend.InterestServiceTest"  # Single test class
+```
+
+### Frontend (`snwa-frontend/`)
+```bash
+npm install
+npm run dev    # Dev server on :3000, proxies /api to localhost:8080
+npm run build  # Production build → ./build/
+```
+
+### Full Stack (root)
+```bash
+docker compose up --build -d   # Start all services (accessible at http://localhost:70)
+```
+
+## Architecture
+
+### System Components
+- **MySQL** → **snwa-backend-blue/green** (port 8080/8081) + **snwa-frontend-blue/green** → **Nginx** (port 70)
+- **Prometheus** scrapes `/actuator/prometheus` every 5s → **Grafana** (port 3000)
+- Nginx dynamically routes via `nginx/conf/service-url.inc` (updated during blue-green deploy)
+
+### Backend Domain Structure
+Domains are under `snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/`:
+
+- `article/` — News articles, search, CRUD
+- `crawler/` — Strategy-pattern scrapers (ESPN, SkySports, etc.) using Selenium + Jsoup
+- `translation/` — Async pipeline: DeepL translates content, Gemini generates 3-line summary + tags
+- `user/` — Auth (JWT 24h), email verification, profiles
+- `payment/` / `order/` / `wallet/` — Toss Payments integration, coin system
+- `exp/` — Experience/level system (attendance, comment rewards)
+- `comment/`, `interest/`, `notification/` — Community and engagement features
+- `global/` — Security config, AOP, JWT filters, cross-cutting utilities
+
+### Frontend Structure
+- `src/pages/` — Route-level pages
+- `src/components/` — Reusable UI (includes `admin/`, `figma/`, `ui/` subdirs)
+- `src/contexts/` — React Context for global state
+- Path alias `@` → `src/`
+
+### Docker Multi-Stage Build
+`DOCKER_TARGET=dev` uses local build artifacts; `DOCKER_TARGET=prod` expects pre-built artifacts injected by CI.
+
+## CI/CD
+
+GitHub Actions (`.github/workflows/gradle.yml`) triggers on merged PRs to `develop`:
+1. Builds backend (JDK 21) and frontend (Node 22) in parallel
+2. SSHs to EC2, detects active blue/green container
+3. Builds and starts the inactive container
+4. Health-checks via `/actuator/health` before switching Nginx routing
+5. Shuts down old container after cutover
+
+## Environment Variables
+
+Copy `.env` and fill in secrets. Key variables:
+- `DOCKER_TARGET` — `dev` (local) or `prod` (CI)
+- `DEEPL_API_KEY`, `GEMINI_API_KEY` — AI translation pipeline
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_S3_BUCKET` — Image storage (ap-northeast-2)
+- `VITE_TOSS_CLIENT_KEY`, `TOSS_SECRET_KEY` — Payment (test keys available)
+- `APP_BASE_URL` — `http://localhost:70` locally

--- a/nginx/conf/default.conf
+++ b/nginx/conf/default.conf
@@ -10,6 +10,24 @@ server {
     # 동적 변수 파일 포함 (여기서 $service_url 값을 가져옴)
     include /etc/nginx/conf.d/service-url.inc;
 
+    location /swagger-ui/ {
+        proxy_pass $service_url;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /v3/api-docs {
+        proxy_pass $service_url;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location /api/ {
         # 변수를 사용하여 Blue(8080) 또는 Green(8081)으로 연결
         proxy_pass $service_url;

--- a/snwa-backend/build.gradle
+++ b/snwa-backend/build.gradle
@@ -92,6 +92,9 @@ dependencies {
     // Monitoring (Actuator & Prometheus)
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // Swagger (springdoc-openapi)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 }
 
 dependencyManagement {

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/global/config/SecurityConfig.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/global/config/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
                                                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                                 .authorizeHttpRequests(auth -> auth
                                                 .requestMatchers("/api/auth/**").permitAll() // 인증 관련 엔드포인트 허용
+                                .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll() // Swagger UI
                                                 .requestMatchers("/actuator/health", "/actuator/prometheus").permitAll() // 시스템
                                                                                                                          // 필수
                                                                                                                          // 모니터링만

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/global/config/SwaggerConfig.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/global/config/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package com.team.snwa.snwabackend.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Value("${app.base-url:http://localhost:70}")
+    private String baseUrl;
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .addServersItem(new Server().url(baseUrl))
+                .info(new Info()
+                        .title("SNWA API")
+                        .description("SNWA 스포츠 뉴스 플랫폼 API")
+                        .version("v1"))
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")))
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
+    }
+}

--- a/snwa-backend/src/main/resources/application.yml
+++ b/snwa-backend/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  forward-headers-strategy: framework
+
 spring:
   application:
     name: snwa-backend


### PR DESCRIPTION
  ## 변경사항                                                                           
  - springdoc-openapi 2.8.5 의존성 추가                                                 
  - SwaggerConfig: Bearer JWT 인증 스킴 및 서버 URL 설정                                
  - SecurityConfig: `/swagger-ui/**`, `/v3/api-docs/**` 인증 없이 접근 허용             
  - application.yml: Nginx 리버스 프록시를 위한 `forward-headers-strategy: framework`   
  추가     