### PR TITLE
fix: Spring AI Gemini 자동구성 충돌 및 테스트 설정 오류 수정

### DIFF
--- a/snwa-backend/src/main/resources/application.yml
+++ b/snwa-backend/src/main/resources/application.yml
@@ -5,6 +5,10 @@ spring:
   application:
     name: snwa-backend
 
+  autoconfigure:
+    exclude:
+      - org.springframework.ai.model.google.genai.autoconfigure.chat.GoogleGenAiChatAutoConfiguration
+
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/snwa?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul}
     username: ${SPRING_DATASOURCE_USERNAME}

--- a/snwa-backend/src/test/resources/application.yml
+++ b/snwa-backend/src/test/resources/application.yml
@@ -49,8 +49,13 @@ spring:
 translation:
   deepl:
     api:
-      key: test-deepl-api-key
+      keys: test-deepl-api-key
       base-url: https://api.test.com
+  gemini:
+    api:
+      keys: test-gemini-api-key
+    model: gemini-2.5-flash
+    temperature: 0.2
 
 jwt:
   secret: this-is-a-very-long-dummy-secret-key-for-test-environment-configuration-to-pass-security-config


### PR DESCRIPTION
- application.yml: GoogleGenAiChatAutoConfiguration 자동구성 제외 (spring.ai.google.genai 설정 제거 후 project-id 누락으로 앱 기동 실패 방지)
- test/application.yml: deepl.api.key → keys 수정, gemini 설정 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **구성 업데이트**
  * 자동 구성 설정을 조정하여 시스템 초기화 프로세스를 최적화했습니다.
  * 번역 서비스 구성을 개선하고 새로운 AI 모델 통합 옵션을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->