### PR TITLE
fix: 블루-그린 배포 시 readiness probe 적용으로 전환 렉 감소

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -194,7 +194,7 @@ jobs:
             # 5. 신규 컨테이너가 뜰 때까지 대기 (Health Check)
             echo "\$NEW 서버가 \$NEW_PORT 포트에서 준비될 때까지 대기 중입니다..."
             for i in {1..20}; do
-              if docker exec snwa-nginx wget -q --spider http://snwa-backend-\$NEW:\$NEW_PORT/actuator/health; then
+              if docker exec snwa-nginx wget -q --spider http://snwa-backend-\$NEW:\$NEW_PORT/actuator/health/readiness; then
                 echo "Success: \$NEW 서버가 정상적으로 응답합니다."
                 break
               fi

--- a/snwa-backend/src/main/resources/application.yml
+++ b/snwa-backend/src/main/resources/application.yml
@@ -102,6 +102,8 @@ management:
   endpoint:
     health:
       show-details: always
+      probes:
+        enabled: true
   metrics:
     tags:
       application: ${spring.application.name} # snwa-backend라는 이름표를 붙여줌


### PR DESCRIPTION
- health check 엔드포인트를 /actuator/health → /actuator/health/readiness로 변경
- application.yml에 Spring Boot health probes 활성화 (probes.enabled: true)
- 트래픽 전환 전 앱 준비 완료 여부를 정확히 확인하여 전환 직후 에러/지연 감소

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 워크플로우의 백엔드 서버 준비 상태 확인 메커니즘이 개선되어 더욱 정확하고 신뢰할 수 있는 상태 감지가 이제 가능해졌습니다. 이로 인해 전반적인 배포 안정성이 향상되며 서버 준비 상태를 더욱 효과적으로 모니터링할 수 있습니다. 기존의 폴링, 재시도 제어 흐름, 그리고 타임아웃 정책은 모두 변경 없이 유지되어 일관되고 예측 가능한 배포 동작이 보장됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->