### PR TITLE
feat: 번역/요약/태그 스케줄러 개별 컨트롤러 분리 및 관리자 UI 추가

### DIFF
--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/controller/KeywordsTagSchedulerController.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/controller/KeywordsTagSchedulerController.java
@@ -1,6 +1,6 @@
 package com.team.snwa.snwabackend.domain.translation.controller;
 
-import com.team.snwa.snwabackend.domain.translation.scheduler.TranslationScheduler;
+import com.team.snwa.snwabackend.domain.translation.scheduler.KeywordsTagScheduler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -12,33 +12,33 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * 번역 스케줄러 수동 실행 컨트롤러 (관리자 전용)
- * 미번역 기사를 찾아 DeepL 번역을 일괄 실행한다.
+ * 태그 추출 스케줄러 수동 실행 컨트롤러 (관리자 전용)
+ * 태그가 없는 번역본을 찾아 Gemini 키워드 추출을 일괄 실행한다.
  */
 @Slf4j
 @RestController
 @RequestMapping("/api/scheduler")
 @RequiredArgsConstructor
-public class TranslationSchedulerController {
+public class KeywordsTagSchedulerController {
 
-    private final TranslationScheduler translationScheduler;
+    private final KeywordsTagScheduler keywordsTagScheduler;
 
-    @PostMapping("/translate")
-    public ResponseEntity<Map<String, String>> runTranslation() {
-        log.info("번역 스케줄러 수동 실행 요청");
+    @PostMapping("/keywords")
+    public ResponseEntity<Map<String, String>> runKeywords() {
+        log.info("태그 추출 스케줄러 수동 실행 요청");
         try {
-            translationScheduler.process();
+            keywordsTagScheduler.process();
 
             Map<String, String> response = new HashMap<>();
             response.put("status", "success");
-            response.put("message", "번역 스케줄러 실행 완료");
+            response.put("message", "태그 추출 스케줄러 실행 완료");
             return ResponseEntity.ok(response);
         } catch (Exception e) {
-            log.error("번역 스케줄러 실행 중 오류 발생", e);
+            log.error("태그 추출 스케줄러 실행 중 오류 발생", e);
 
             Map<String, String> response = new HashMap<>();
             response.put("status", "error");
-            response.put("message", "번역 스케줄러 실행 실패: " + e.getMessage());
+            response.put("message", "태그 추출 스케줄러 실행 실패: " + e.getMessage());
             return ResponseEntity.internalServerError().body(response);
         }
     }

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/controller/SummarySchedulerController.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/controller/SummarySchedulerController.java
@@ -1,6 +1,6 @@
 package com.team.snwa.snwabackend.domain.translation.controller;
 
-import com.team.snwa.snwabackend.domain.translation.scheduler.TranslationScheduler;
+import com.team.snwa.snwabackend.domain.translation.scheduler.SummaryScheduler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -12,33 +12,33 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * 번역 스케줄러 수동 실행 컨트롤러 (관리자 전용)
- * 미번역 기사를 찾아 DeepL 번역을 일괄 실행한다.
+ * 요약 스케줄러 수동 실행 컨트롤러 (관리자 전용)
+ * 요약이 없는 번역본을 찾아 Gemini 요약을 일괄 실행한다.
  */
 @Slf4j
 @RestController
 @RequestMapping("/api/scheduler")
 @RequiredArgsConstructor
-public class TranslationSchedulerController {
+public class SummarySchedulerController {
 
-    private final TranslationScheduler translationScheduler;
+    private final SummaryScheduler summaryScheduler;
 
-    @PostMapping("/translate")
-    public ResponseEntity<Map<String, String>> runTranslation() {
-        log.info("번역 스케줄러 수동 실행 요청");
+    @PostMapping("/summary")
+    public ResponseEntity<Map<String, String>> runSummary() {
+        log.info("요약 스케줄러 수동 실행 요청");
         try {
-            translationScheduler.process();
+            summaryScheduler.process();
 
             Map<String, String> response = new HashMap<>();
             response.put("status", "success");
-            response.put("message", "번역 스케줄러 실행 완료");
+            response.put("message", "요약 스케줄러 실행 완료");
             return ResponseEntity.ok(response);
         } catch (Exception e) {
-            log.error("번역 스케줄러 실행 중 오류 발생", e);
+            log.error("요약 스케줄러 실행 중 오류 발생", e);
 
             Map<String, String> response = new HashMap<>();
             response.put("status", "error");
-            response.put("message", "번역 스케줄러 실행 실패: " + e.getMessage());
+            response.put("message", "요약 스케줄러 실행 실패: " + e.getMessage());
             return ResponseEntity.internalServerError().body(response);
         }
     }

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/scheduler/KeywordsTagScheduler.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/scheduler/KeywordsTagScheduler.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -46,11 +47,13 @@ public class KeywordsTagScheduler {
                     page.getTotalElements(), translations.size());
 
             int failCount = 0;
+            List<Long> successIds = new ArrayList<>();
 
             for (ArticleTranslation translation : translations) {
                 try {
                     log.debug("기사 키워드 추출 시작: articleId={}", translation.getArticle().getId());
                     keywordExtractionService.extractKeywords(translation.getArticle().getId(), "KO");
+                    successIds.add(translation.getArticle().getId());
                     Thread.sleep(API_DELAY_MS);
                 } catch (Exception e) {
                     failCount++;
@@ -58,8 +61,8 @@ public class KeywordsTagScheduler {
                 }
             }
 
-            log.info("✅ 키워드 태그 추출 스케줄러 완료: 성공 {}, 실패 {}",
-                    translations.size() - failCount, failCount);
+            log.info("✅ 키워드 태그 추출 스케줄러 완료: articleId {} 태그 추출 완료 (성공 {}, 실패 {})",
+                    successIds, successIds.size(), failCount);
         } catch (Exception e) {
             log.error("키워드 태그 추출 스케줄러 실행 중 오류 발생", e);
             throw e;

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/scheduler/SummaryScheduler.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/scheduler/SummaryScheduler.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -48,6 +49,7 @@ public class SummaryScheduler {
                     page.getTotalElements(), translations.size());
 
             int failCount = 0;
+            List<Long> successIds = new ArrayList<>();
 
             for (ArticleTranslation translation : translations) {
                 try {
@@ -57,6 +59,7 @@ public class SummaryScheduler {
                                     ? translation.getTranslatedContent().length()
                                     : 0);
                     summaryService.summarizeArticle(translation.getArticle().getId());
+                    successIds.add(translation.getArticle().getId());
                     Thread.sleep(API_DELAY_MS);
                 } catch (Exception e) {
                     failCount++;
@@ -64,8 +67,8 @@ public class SummaryScheduler {
                 }
             }
 
-            log.info("✅ 요약 스케줄러 완료: 성공 {}, 실패 {}",
-                    translations.size() - failCount, failCount);
+            log.info("✅ 요약 스케줄러 완료: articleId {} 요약 완료 (성공 {}, 실패 {})",
+                    successIds, successIds.size(), failCount);
         } catch (Exception e) {
             log.error("요약 스케줄러 실행 중 오류 발생", e);
             throw e;

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/scheduler/TranslationScheduler.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/scheduler/TranslationScheduler.java
@@ -2,13 +2,14 @@ package com.team.snwa.snwabackend.domain.translation.scheduler;
 
 import com.team.snwa.snwabackend.domain.article.entity.Article;
 import com.team.snwa.snwabackend.domain.article.repository.ArticleRepository;
-import com.team.snwa.snwabackend.domain.translation.service.ArticleOrchestratorService;
+import com.team.snwa.snwabackend.domain.translation.service.TranslationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -21,7 +22,7 @@ import java.util.List;
 public class TranslationScheduler {
 
     private final ArticleRepository articleRepository;
-    private final ArticleOrchestratorService articleOrchestratorService;
+    private final TranslationService translationService;
 
     private static final int BATCH_SIZE = 2; // 한 번에 처리할 기사 개수
     private static final long API_DELAY_MS = 4000;
@@ -46,11 +47,13 @@ public class TranslationScheduler {
                     page.getTotalElements(), articles.size());
 
             int failCount = 0;
+            List<Long> successIds = new ArrayList<>();
 
             for (Article article : articles) {
                 try {
                     log.debug("기사 번역 시작: articleId={}", article.getId());
-                    articleOrchestratorService.translateArticle(article.getId());
+                    translationService.getOrTranslate(article.getId(), "KO");
+                    successIds.add(article.getId());
                     Thread.sleep(API_DELAY_MS);
                 } catch (Exception e) {
                     failCount++;
@@ -58,8 +61,8 @@ public class TranslationScheduler {
                 }
             }
 
-            log.info("✅ 번역 스케줄러 완료: 성공 {}, 실패 {}",
-                    articles.size() - failCount, failCount);
+            log.info("✅ 번역 스케줄러 완료: articleId {} 번역 완료 (성공 {}, 실패 {})",
+                    successIds, successIds.size(), failCount);
         } catch (Exception e) {
             log.error("번역 스케줄러 실행 중 오류 발생", e);
             throw e;

--- a/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/service/KeywordExtractionService.java
+++ b/snwa-backend/src/main/java/com/team/snwa/snwabackend/domain/translation/service/KeywordExtractionService.java
@@ -86,7 +86,7 @@ public class KeywordExtractionService {
 
         // 키워드 파싱 - Map<키워드, 타입>
         Map<String, InterestType> typedKeywords = extractKeywordsFromContent(contentToExtract, targetLang);
-        List<String> keywordList = new ArrayList<>(typedKeywords.keySet());
+        List<String> keywordList = new ArrayList<>(typedKeywords.keySet()); // 벨류값은 버리고 키값만 사용 keywordList = ["손흥민", "토트넘"]
 
         // ArticleTag 엔티티 생성 및 저장
         for (String keyword : keywordList) {
@@ -159,7 +159,7 @@ public class KeywordExtractionService {
         // 프롬프트 내 {language} 치환 추가
         String prompt = promptTemplate.replace("{translatedContent}", translatedContent).replace("{language}",
                 languageName);
-        String keywordsResponse = geminiClientManager.generate(prompt);
+        String keywordsResponse = geminiClientManager.generate(prompt); // keywordsResponse = 태그추출이 완료된 데이터
         return parseTypedKeywords(keywordsResponse);
     }
 

--- a/snwa-frontend/src/components/admin/TranslationManager.tsx
+++ b/snwa-frontend/src/components/admin/TranslationManager.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo } from 'react';
-import { Search, Eye, Tag, Globe } from 'lucide-react';
+import { Search, Eye, Tag, Globe, Languages, FileText, RefreshCw } from 'lucide-react';
 
 // [변경] 백엔드 DTO 구조에 맞춘 새 타입 정의
 type TranslationDetail = {
@@ -16,11 +16,43 @@ type AdminArticleGroup = {
     translations: TranslationDetail[];
 };
 
+type SchedulerKey = 'translate' | 'summary' | 'keywords';
+
+async function runScheduler(type: SchedulerKey): Promise<string> {
+    const token = sessionStorage.getItem('snwa_token');
+    const res = await fetch(`/api/scheduler/${type}`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+    });
+    const json = await res.json();
+    if (!res.ok) throw new Error(json.message || '실행 실패');
+    return json.message;
+}
+
 export default function TranslationManager() {
     const [data, setData] = useState<AdminArticleGroup[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
     const [search, setSearch] = useState('');
+    const [schedulerLoading, setSchedulerLoading] = useState<Record<SchedulerKey, boolean>>({
+        translate: false, summary: false, keywords: false,
+    });
+    const [schedulerMsg, setSchedulerMsg] = useState<Record<SchedulerKey, string>>({
+        translate: '', summary: '', keywords: '',
+    });
+
+    const handleScheduler = async (type: SchedulerKey) => {
+        setSchedulerLoading(prev => ({ ...prev, [type]: true }));
+        setSchedulerMsg(prev => ({ ...prev, [type]: '' }));
+        try {
+            const msg = await runScheduler(type);
+            setSchedulerMsg(prev => ({ ...prev, [type]: msg }));
+        } catch (e) {
+            setSchedulerMsg(prev => ({ ...prev, [type]: e instanceof Error ? e.message : '오류 발생' }));
+        } finally {
+            setSchedulerLoading(prev => ({ ...prev, [type]: false }));
+        }
+    };
 
     // 상세보기 모달용 상태
     const [selectedDetail, setSelectedDetail] = useState<{ id: number; detail: TranslationDetail } | null>(null);
@@ -65,19 +97,50 @@ export default function TranslationManager() {
 
     return (
         <div className="space-y-6">
-            {/* 검색바 */}
-            <div className="flex items-center gap-4">
-                <div className="relative flex-1 max-w-sm">
-                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
-                    <input
-                        type="text"
-                        placeholder="ID, 제목, 태그로 검색..."
-                        value={search}
-                        onChange={(e) => setSearch(e.target.value)}
-                        className="w-full pl-10 pr-4 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-900"
-                    />
+            {/* 검색바 + 스케줄러 버튼 */}
+            <div className="flex items-start justify-between gap-4 flex-wrap">
+                <div className="flex items-center gap-4">
+                    <div className="relative flex-1 max-w-sm">
+                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                        <input
+                            type="text"
+                            placeholder="ID, 제목, 태그로 검색..."
+                            value={search}
+                            onChange={(e) => setSearch(e.target.value)}
+                            className="w-full pl-10 pr-4 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-900"
+                        />
+                    </div>
+                    <div className="text-sm text-gray-500">총 {filtered.length}건 (기사 기준)</div>
                 </div>
-                <div className="text-sm text-gray-500">총 {filtered.length}건 (기사 기준)</div>
+
+                {/* 스케줄러 수동 실행 */}
+                <div className="flex items-center gap-2">
+                    {([
+                        { key: 'translate' as SchedulerKey, label: '번역', Icon: Languages },
+                        { key: 'summary' as SchedulerKey, label: '요약', Icon: FileText },
+                        { key: 'keywords' as SchedulerKey, label: '태그', Icon: Tag },
+                    ] as const).map(({ key, label, Icon }) => (
+                        <div key={key} className="flex flex-col items-center gap-1">
+                            <button
+                                onClick={() => handleScheduler(key)}
+                                disabled={schedulerLoading[key]}
+                                title={`${label} 스케줄러 실행`}
+                                className="flex items-center gap-1.5 px-3 py-2 text-xs font-medium text-gray-600 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 hover:border-gray-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                            >
+                                {schedulerLoading[key]
+                                    ? <RefreshCw className="w-3.5 h-3.5 animate-spin" />
+                                    : <Icon className="w-3.5 h-3.5" />
+                                }
+                                {label}
+                            </button>
+                            {schedulerMsg[key] && (
+                                <span className="text-[10px] text-gray-400 max-w-[80px] text-center leading-tight">
+                                    {schedulerMsg[key]}
+                                </span>
+                            )}
+                        </div>
+                    ))}
+                </div>
             </div>
 
             {/* 테이블 */}


### PR DESCRIPTION
- TranslationSchedulerController를 번역/요약/태그 전용 컨트롤러 3개로 분리
- TranslationScheduler가 번역만 처리하도록 수정 (OrchestrationService → TranslationService)
- 각 스케줄러 완료 로그에 처리된 articleId 목록 추가
- 프론트엔드 TranslationManager에 스케줄러 수동 실행 버튼 3개 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 관리자용 스케줄러 수동 실행 API 추가 (번역, 요약, 태그 추출)
  * 관리 대시보드에서 각 스케줄러를 독립적으로 실행할 수 있는 버튼 추가
  * 스케줄러 실행 결과 추적 기능 개선으로 성공/실패 작업 명확화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->